### PR TITLE
Warning goal fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,13 +42,17 @@ def main():
             # Update the previous day's points data
             previous_points_data[account_name] = earned_points
 
-            print(f"[POINTS] data for '{account_name}' appended to the file.")
+            logging.info(
+                f"[POINTS] Data for '{account_name}' appended to the file."
+            )
         except Exception as e:
             logging.exception(f"{e.__class__.__name__}: {e}")
 
     # Save the current day's points data for the next day in the "logs" folder
     save_previous_points_data(previous_points_data)
-    print("Points data saved for the next day.")
+    logging.info(
+        f"[POINTS] Data saved for the next day."
+    )
 
 def log_daily_points_to_csv(date, earned_points, points_difference):
     logs_directory = Path(__file__).resolve().parent / "logs"
@@ -203,6 +207,7 @@ def executeBot(currentAccount, notifier: Notifier, args: argparse.Namespace):
         goalTitle = desktopBrowser.utils.getGoalTitle()
         desktopBrowser.closeBrowser()
     
+    remainingSearchesM = 1
     if remainingSearchesM != 0:
         desktopBrowser.closeBrowser()
         with Browser(mobile=True, account=currentAccount, args=args) as mobileBrowser:

--- a/src/browser.py
+++ b/src/browser.py
@@ -51,7 +51,6 @@ class Browser:
         """Perform actions to close the browser cleanly."""
         # close web browser
         with contextlib.suppress(Exception):
-            self.webdriver.close()
             self.webdriver.quit()
 
     def browserSetup(


### PR DESCRIPTION
Have made some changes.

- I removed the driver.close() in the closeBrowser function because this was causing the endless warnings at the end. driver.quit() fully closes and quits the webdriver. the close() closes the active tab so when both are invoked the tab get's closed and browser also. when now the quit() also get's invoked then comes the warning because nothing is open 😄 
- there was a problem with the new goal stuff, wenn there was 1 mobile search left it crashes... so I now have moved the mobileBrowser stuff out of the runtime of the desktopBrowser and "doubled" the goal stuff. (maybe also some preps to flag only desktop only mobile runs)
- changes some of the new print lines regarding the csv stuff to get logged like the other stuff


maybe you can have a look over this changes and merge them, at my side now everything works fine.