### PR TITLE
added argument "chromeversion"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@
   ```(ex: https://discord.com/api/webhooks/123456789/ABCdefGhIjKlmNoPQRsTUVwxyZ)```
 - -vn/--verbose notifications to notification listeners (Discord, Telegram)
 
+- -cv/--chromeversion to use a specifiv version of chrome
+
+  ```(ex: 118)```
 ---
 
 ## Features

--- a/main.py
+++ b/main.py
@@ -143,6 +143,13 @@ def argumentParser() -> argparse.Namespace:
         action="store_true",
         help="Optional: Send all the logs to discord/telegram",
     )
+    parser.add_argument(
+        "-cv",
+        "--chromeversion",
+        type=int,
+        default=None,
+        help="Optional: Set fixed Chrome version (ex. 118)",
+    )
     return parser.parse_args()
 
 

--- a/src/browser.py
+++ b/src/browser.py
@@ -40,6 +40,7 @@ class Browser:
         self.password = account["password"]
         self.localeLang, self.localeGeo = self.getCCodeLang(args.lang, args.geo)
         self.proxy = None
+        self.chromeversion = args.chromeversion
         if args.proxy:
             self.proxy = args.proxy
         elif account.get("proxy"):
@@ -90,7 +91,11 @@ class Browser:
                 "no_proxy": "localhost,127.0.0.1",
             }
 
+        if(self.chromeversion != None):
+            logging.info(f"Chrome version: {self.chromeversion}")
+            
         driver = webdriver.Chrome(
+            version_main=self.chromeversion,
             options=options,
             seleniumwire_options=seleniumwireOptions,
             user_data_dir=self.userDataDir.as_posix(),


### PR DESCRIPTION
Since I have problems with early closed tabs in Chrome version 119 I have added the abbility to select a specific Chrome version as an argument.
So we can execute the script with an older/fixed version of Chrome.
If no argument is passed, then the most recent version of Chromedriver is used