### PR TITLE
Fix stalling on 'Writing password...'

### DIFF
--- a/src/login.py
+++ b/src/login.py
@@ -73,7 +73,7 @@ class Login:
         while not (
             urllib.parse.urlparse(self.webdriver.current_url).path == "/"
             and urllib.parse.urlparse(self.webdriver.current_url).hostname
-            == "account.microsoft.com"
+            in ("account.microsoft.com", "rewards.bing.com")
         ):
             if "Abuse" in str(self.webdriver.current_url):
                 logging.error(f"[LOGIN] {self.browser.username} is locked")
@@ -81,9 +81,7 @@ class Login:
             self.utils.tryDismissAllMessages()
             time.sleep(1)
 
-        self.utils.waitUntilVisible(
-            By.CSS_SELECTOR, 'html[data-role-name="MeePortal"]', 10
-        )
+        time.sleep(10)
 
     def enterPassword(self, password):
         self.utils.waitUntilClickable(By.NAME, "passwd", 10)


### PR DESCRIPTION
-Added support for `https://rewards.bing.com/` hostname to prevent stalling in `execute_login` function. 
-Replaced subsequent `self.utils.waitUntilVisible` call with `time.sleep(10)` to prevent timeout error when visiting new hostname.
-Changes should fix stalling on 'Writing password...' stage.