### PR TITLE
Handle "Stay signed in?" window

### DIFF
--- a/src/login.py
+++ b/src/login.py
@@ -75,6 +75,9 @@ class Login:
             and urllib.parse.urlparse(self.webdriver.current_url).hostname
             == "account.microsoft.com"
         ):
+            if urllib.parse.urlparse(self.webdriver.current_url).hostname == "rewards.bing.com":
+                self.webdriver.get("https://account.microsoft.com")
+            
             if "Abuse" in str(self.webdriver.current_url):
                 logging.error(f"[LOGIN] {self.browser.username} is locked")
                 return True

--- a/src/utils.py
+++ b/src/utils.py
@@ -202,6 +202,7 @@ class Utils:
             (By.ID, "idSIButton9"),
             (By.CSS_SELECTOR, ".ms-Button.ms-Button--primary"),
             (By.ID, "bnp_btn_accept"),
+            (By.ID, "acceptButton")
         ]
         result = False
         for button in buttons:


### PR DESCRIPTION
This PR attempts to fix the "Stay signed in?" dialog which can occur when logging in.

Of note, this adds `#acceptButton` to the list of items that `tryDismissAllMessages` triggers. This could cause issues however I'm unsure.

Also, it seems that when the accept button is pressed, we are routed to the rewards page itself instead of the account page. Due to this, I've added a check which moves us over to account.microsoft.com. This could be implemented better however works just fine as is and could act as extra assurance that we've logged in.