### PR TITLE
Resolves #95

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas
 numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=69.0.2 # not directly required, pinned by Snyk to avoid a vulnerability
 psutil
+blinker==1.7.0


### PR DESCRIPTION
Resolves error cause by version 1.8.0 or newer as _saferef was deleted for that release. I don't know enough about any of these codebases but forcing the use of 1.7.0 should stop it from not working for now