### PR TITLE
Moble Search Fix

### DIFF
--- a/src/browser.py
+++ b/src/browser.py
@@ -52,7 +52,7 @@ class Browser:
         """Perform actions to close the browser cleanly."""
         # Close the web browser
         with contextlib.suppress(Exception):
-            self.webdriver.close()
+            self.webdriver.quit()
 
     def browserSetup(
         self,
@@ -62,7 +62,7 @@ class Browser:
         options.headless = self.headless
         options.add_argument(f"--lang={self.localeLang}")
         options.add_argument("--log-level=3")
-        #options.add_argument("--blink-settings=imagesEnabled=false")
+        # options.add_argument("--blink-settings=imagesEnabled=false")
         options.add_argument("--ignore-certificate-errors")
         options.add_argument("--ignore-certificate-errors-spki-list")
         options.add_argument("--ignore-ssl-errors")


### PR DESCRIPTION
Switched from webdriver.close to webdriver.quit in browser.py so it properly cleans up the session and allows mobile searches to begin. Tested on my end to ensure it works properly and starts mobile searches as expected. This fixes  issue #102   