### PR TITLE
Remove VersusGame import

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from src import (
     MorePromotions,
     PunchCards,
     Searches,
-    VersusGame,
+    # VersusGame,
 )
 from src.loggingColoredFormatter import ColoredFormatter
 from src.utils import Utils


### PR DESCRIPTION
Remove import of VersusGame which causes an error on script start

```bash
ImportError: cannot import name 'VersusGame' from 'src'
```