### PR TITLE
Fix bug when sending notification

### DIFF
--- a/main.py
+++ b/main.py
@@ -200,10 +200,10 @@ def executeBot(currentAccount, args: argparse.Namespace):
         accountPointsCounter = Login(desktopBrowser).login()
         startingPoints = accountPointsCounter
         if startingPoints == "Locked":
-            utils.send_notification("🚫 Account is Locked", currentAccount["username"])
+            Utils.send_notification("🚫 Account is Locked", currentAccount["username"])
             return 0
         if startingPoints == "Verify":
-            utils.send_notification("❗️ Account needs to be verified", currentAccount["username"])
+            Utils.send_notification("❗️ Account needs to be verified", currentAccount["username"])
             return 0
         logging.info(
             f"[POINTS] You have {utils.formatNumber(accountPointsCounter)} points on your account"
@@ -265,7 +265,7 @@ def executeBot(currentAccount, args: argparse.Namespace):
         )
         goalNotifier = f"🎯 Goal reached: {(utils.formatNumber((accountPointsCounter / goalPoints) * 100))}% ({goalTitle})"
 
-    utils.send_notification(
+    Utils.send_notification(
         "Daily Points Update",
         "\n".join(
             [

--- a/src/utils.py
+++ b/src/utils.py
@@ -32,9 +32,10 @@ class Utils:
         with open(config_file, 'r') as file:
             return yaml.safe_load(file)
 
-    def send_notification(self, title, body):
+    @staticmethod
+    def send_notification(title, body, config_file='config.yaml'):
         apobj = apprise.Apprise()
-        for url in self.config['apprise']['urls']:
+        for url in Utils.load_config(config_file)['apprise']['urls']:
             apobj.add(url)
         apobj.notify(body=body, title=title)
 


### PR DESCRIPTION
To reproduce the bug, raise an exception somewhere in [this block](https://github.com/klept0/MS-Rewards-Farmer/blob/198d6add1002be16ddd0571804093123392e8bf9/main.py#L42-L55). Notice that the call fails because `send_notification` can't be accessed statically.

This PR makes it so the method can be accessed statically, fixing the bug.