### PR TITLE
Add Extra --no-sandbox

### DIFF
--- a/src/browser.py
+++ b/src/browser.py
@@ -200,7 +200,7 @@ class Browser:
     def getChromeVersion(self) -> str:
         chrome_options = ChromeOptions()
         chrome_options.add_argument("--headless=new")
-
+        chrome_options.add_argument("--no-sandbox")
         driver = WebDriver(options=chrome_options)
         version = driver.capabilities["browserVersion"]
 


### PR DESCRIPTION
Adding --no-sandbox option in def getChromeVersion(self) needed to run in docker headless. Get 

Confirmed did not affect running normally in Windows.

Without switch, get following error:

`selenium.common.exceptions.SessionNotCreatedException: Message: session not created: Chrome failed to start: exited normally.
  (session not created: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)`

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Added the --no-sandbox option to the Chrome WebDriver configuration in the getChromeVersion method to ensure compatibility with Docker headless environments.

<!-- Generated by sourcery-ai[bot]: end summary -->