### PR TITLE
def closeBrowser(self) use .quit() instead of .close()

### DIFF
--- a/main.py
+++ b/main.py
@@ -239,7 +239,6 @@ def executeBot(currentAccount, args: argparse.Namespace):
         desktopBrowser.closeBrowser()
 
     if remainingSearchesM != 0:
-        desktopBrowser.closeBrowser()
         with Browser(mobile=True, account=currentAccount, args=args) as mobileBrowser:
             utils = mobileBrowser.utils
             accountPointsCounter = Login(mobileBrowser).login()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psutil
 blinker==1.7.0 #prevents issues on newer versions
 apprise
 pyyaml
+urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/src/browser.py
+++ b/src/browser.py
@@ -53,7 +53,7 @@ class Browser:
         """Perform actions to close the browser cleanly."""
         # Close the web browser
         with contextlib.suppress(Exception):
-            self.webdriver.close()
+            self.webdriver.quit()
                        
     def browserSetup(
         self,


### PR DESCRIPTION
Using .close() in def closeBrowser(self) caused a crash when restarting the session in mobile browser mode in my docker container. Changing to .quit(), which is also used in def getChromeVersion(self) allowed the mobile mode to start out. I tested in non-docker and it did not cause an issue