### PR TITLE
Added "Read to Earn" Capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,5 +122,6 @@
 
 ## To Do List (When time permits or someone makes a PR)
 
-- [ ] Complete "Read To Earn" (30 pts)
+- [x] Complete "Read To Earn" (30 pts)
 - [ ] Setup flags for mobile/desktop search only
+- [ ] Setup flags to load config / save data in working directory 

--- a/main.py
+++ b/main.py
@@ -209,10 +209,10 @@ def executeBot(currentAccount, args: argparse.Namespace):
         logging.info(
             f"[POINTS] You have {utils.formatNumber(accountPointsCounter)} points on your account"
         )
+        ReadToEarn(desktopBrowser).completeReadToEarn()
         DailySet(desktopBrowser).completeDailySet()
         PunchCards(desktopBrowser).completePunchCards()
         MorePromotions(desktopBrowser).completeMorePromotions()
-        ReadToEarn(desktopBrowser).completeReadToEarn()
         # VersusGame(desktopBrowser).completeVersusGame()
         (
             remainingSearches,

--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ def executeBot(currentAccount, args: argparse.Namespace):
         logging.info(
             f"[POINTS] You have {utils.formatNumber(accountPointsCounter)} points on your account"
         )
-        ReadToEarn(desktopBrowser).completeReadToEarn()
+        ReadToEarn(desktopBrowser).completeReadToEarn(startingPoints)
         DailySet(desktopBrowser).completeDailySet()
         PunchCards(desktopBrowser).completePunchCards()
         MorePromotions(desktopBrowser).completeMorePromotions()

--- a/main.py
+++ b/main.py
@@ -209,10 +209,10 @@ def executeBot(currentAccount, args: argparse.Namespace):
         logging.info(
             f"[POINTS] You have {utils.formatNumber(accountPointsCounter)} points on your account"
         )
-        ReadToEarn(desktopBrowser).completeReadToEarn()
         DailySet(desktopBrowser).completeDailySet()
         PunchCards(desktopBrowser).completePunchCards()
         MorePromotions(desktopBrowser).completeMorePromotions()
+        ReadToEarn(desktopBrowser).completeReadToEarn()
         # VersusGame(desktopBrowser).completeVersusGame()
         (
             remainingSearches,

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from src import (
     MorePromotions,
     PunchCards,
     Searches,
+    ReadToEarn,
 )
 from src.loggingColoredFormatter import ColoredFormatter
 from src.utils import Utils
@@ -208,6 +209,7 @@ def executeBot(currentAccount, args: argparse.Namespace):
         logging.info(
             f"[POINTS] You have {utils.formatNumber(accountPointsCounter)} points on your account"
         )
+        ReadToEarn(desktopBrowser).completeReadToEarn()
         DailySet(desktopBrowser).completeDailySet()
         PunchCards(desktopBrowser).completePunchCards()
         MorePromotions(desktopBrowser).completeMorePromotions()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,4 @@ blinker==1.7.0 #prevents issues on newer versions
 apprise
 pyyaml
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
-OAuth2Session
-secrets
-time
-random
+requests-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ blinker==1.7.0 #prevents issues on newer versions
 apprise
 pyyaml
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
+OAuth2Session
+secrets
+time
+random

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,3 +4,4 @@ from .login import Login
 from .morePromotions import MorePromotions
 from .punchCards import PunchCards
 from .searches import Searches
+from .readToEarn import ReadToEarn

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -53,7 +53,7 @@ class ReadToEarn:
                 redirect_response = self.webdriver.current_url
                 break
             time.sleep(1)
-        
+        self.browser.utils.closeCurrentTab()
         logging.info("[READ TO EARN] - Logged-in successfully !")
         # Use returned URL to create a token
         token = mobileApp.fetch_token(token_url, authorization_response=redirect_response,include_client_id=True)

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -76,7 +76,6 @@ class ReadToEarn:
         balance = 0
         # 10 is the most points you can get
         for i in range(10):
-            logging.info("[READ TO EARN] - Reading Article " + str(i+1))
             # Replace ID with a random value so get credit for a new article
             json_data['id'] = secrets.token_hex(64)
             r = mobileApp.post("https://prod.rewardsplatform.microsoft.com/dapi/me/activities",json=json_data)
@@ -85,6 +84,7 @@ class ReadToEarn:
                 logging.info("[READ TO EARN] - Read All Available Articles !")
                 break;
             else:
+                logging.info("[READ TO EARN] - Read Article " + str(i+1))
                 balance = newbalance
                 time.sleep(random.randint(10, 20))
         

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -49,7 +49,7 @@ class ReadToEarn:
         # Get Referer URL from webdriver
         self.webdriver.get(authorization_url)
         while True:
-            logging.info("[Read to Earn] - Waiting for Login")
+            logging.info("[READ TO EARN] - Waiting for Login")
             if self.webdriver.current_url[:48] == "https://login.live.com/oauth20_desktop.srf?code=":
                 redirect_response = self.webdriver.current_url
                 break
@@ -58,7 +58,7 @@ class ReadToEarn:
         time.sleep(Utils.randomSeconds(10, 15))
         self.browser.utils.closeCurrentTab()
         
-        logging.info("[READ TO EARN] - Logged-in successfully !")
+        logging.info("[READ TO EARN] Logged-in successfully !")
         # Use returned URL to create a token
         token = mobileApp.fetch_token(token_url, authorization_response=redirect_response,include_client_id=True)
         
@@ -81,10 +81,10 @@ class ReadToEarn:
             r = mobileApp.post("https://prod.rewardsplatform.microsoft.com/dapi/me/activities",json=json_data)
             newbalance = r.json().get("response").get("balance")
             if newbalance == balance:
-                logging.info("[READ TO EARN] - Read All Available Articles !")
+                logging.info("[READ TO EARN] Read All Available Articles !")
                 break;
             else:
-                logging.info("[READ TO EARN] - Read Article " + str(i+1))
+                logging.info("[READ TO EARN] Read Article " + str(i+1))
                 balance = newbalance
                 time.sleep(random.randint(10, 20))
         

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -25,7 +25,7 @@ class ReadToEarn:
         self.webdriver = browser.webdriver
         self.activities = Activities(browser)
     
-    def completeReadToEarn(self):
+    def completeReadToEarn(self,startingPoints):
         
         logging.info("[READ TO EARN] " + "Trying to complete Read to Earn...")
            
@@ -70,7 +70,7 @@ class ReadToEarn:
                 },
             }
 
-        balance = 0
+        balance = startingPoints
         # 10 is the most points you can get
         for i in range(10):
             # Replace ID with a random value so get credit for a new article

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -79,7 +79,7 @@ class ReadToEarn:
             newbalance = r.json().get("response").get("balance")
             if newbalance == balance:
                 logging.info("[READ TO EARN] Read All Available Articles !")
-                break;
+                break
             else:
                 logging.info("[READ TO EARN] Read Article " + str(i+1))
                 balance = newbalance

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -1,0 +1,87 @@
+import logging
+import urllib.parse
+from datetime import datetime
+
+from src.browser import Browser
+
+from .activities import Activities
+
+import requests
+from requests_oauthlib import OAuth2Session
+import secrets
+import time
+import random
+
+client_id = '0000000040170455'
+authorization_base_url = 'https://login.live.com/oauth20_authorize.srf'
+token_url = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token'
+redirect_uri = ' https://login.live.com/oauth20_desktop.srf'
+scope = [ "service::prod.rewardsplatform.microsoft.com::MBI_SSL"]
+
+class ReadToEarn:
+    def __init__(self, browser: Browser):
+        self.browser = browser
+        self.webdriver = browser.webdriver
+        self.activities = Activities(browser)
+    
+    def completeReadToEarn(self):
+        
+        logging.info("[READ TO EARN] " + "Trying to complete Read to Earn...")
+           
+        accountName = self.browser.username
+        
+        # Should Really Cache Token and load it in.
+        # To Save token
+        #with open('token.pickle', 'wb') as f:
+        #    pickle.dump(token, f)
+        # To Load token
+        #with open('token.pickle', 'rb') as f:
+        #   token = pickle.load(f)
+        #mobileApp = OAuth2Session(client_id, scope=scope, token=token)
+        
+        # Use Webdriver to get OAuth2 Token
+        # This works, since you already logged into Bing, so no user interaction needed
+        
+        mobileApp = OAuth2Session(client_id, scope=scope, redirect_uri=redirect_uri)
+        authorization_url, state = mobileApp.authorization_url(authorization_base_url, access_type="offline_access", login_hint=accountName)
+        
+        # Get Referer URL from webdriver
+        self.webdriver.get(authorization_url)
+        while True:
+            logging.info("[Read to Earn] - Waiting for Login")
+            if self.webdriver.current_url[:48] == "https://login.live.com/oauth20_desktop.srf?code=":
+                redirect_response = self.webdriver.current_url
+                break
+            time.sleep(1)
+        
+        logging.info("[READ TO EARN] - Logged-in successfully !")
+        # Use returned URL to create a token
+        token = mobileApp.fetch_token(token_url, authorization_response=redirect_response,include_client_id=True)
+        
+        # json data to confirm an article is run
+        json_data = {
+            'amount': 1,
+            'country': 'us',
+            'id': 1,
+            'type': 101,
+            'attributes': {
+                'offerid': 'ENUS_readarticle3_30points',
+                },
+            }
+
+        balance = 0
+        # 10 is the most points you can get
+        for i in range(10):
+            logging.info("[READ TO EARN] - Reading Article " + str(i+1))
+            # Replace ID with a random value so get credit for a new article
+            json_data['id'] = secrets.token_hex(64)
+            r = mobileApp.post("https://prod.rewardsplatform.microsoft.com/dapi/me/activities",json=json_data)
+            newbalance = r.json().get("response").get("balance")
+            if newbalance == balance:
+                logging.info("[READ TO EARN] - Read All Available Articles !")
+                break;
+            else:
+                balance = newbalance
+                time.sleep(random.randint(10, 20))
+        
+        logging.info("[READ TO EARN] Completed the Read to Earn successfully !") 

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -59,7 +59,7 @@ class ReadToEarn:
         # Use returned URL to create a token
         token = mobileApp.fetch_token(token_url, authorization_response=redirect_response,include_client_id=True)
         
-        # json data to confirm an article is run
+        # json data to confirm an article is read
         json_data = {
             'amount': 1,
             'country': 'us',
@@ -71,7 +71,7 @@ class ReadToEarn:
             }
 
         balance = startingPoints
-        # 10 is the most points you can get
+        # 10 is the most articles you can read. Sleep time is a guess, not tuned
         for i in range(10):
             # Replace ID with a random value so get credit for a new article
             json_data['id'] = secrets.token_hex(64)

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -49,7 +49,7 @@ class ReadToEarn:
         # Get Referer URL from webdriver
         self.webdriver.get(authorization_url)
         while True:
-            logging.info("[READ TO EARN] - Waiting for Login")
+            logging.info("[READ TO EARN] Waiting for Login")
             if self.webdriver.current_url[:48] == "https://login.live.com/oauth20_desktop.srf?code=":
                 redirect_response = self.webdriver.current_url
                 break

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -55,9 +55,6 @@ class ReadToEarn:
                 break
             time.sleep(1)
             
-        time.sleep(Utils.randomSeconds(10, 15))
-        self.browser.utils.closeCurrentTab()
-        
         logging.info("[READ TO EARN] Logged-in successfully !")
         # Use returned URL to create a token
         token = mobileApp.fetch_token(token_url, authorization_response=redirect_response,include_client_id=True)

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -3,6 +3,7 @@ import urllib.parse
 from datetime import datetime
 
 from src.browser import Browser
+from src.utils import Utils
 
 from .activities import Activities
 
@@ -53,7 +54,10 @@ class ReadToEarn:
                 redirect_response = self.webdriver.current_url
                 break
             time.sleep(1)
+            
+        time.sleep(Utils.randomSeconds(10, 15))
         self.browser.utils.closeCurrentTab()
+        
         logging.info("[READ TO EARN] - Logged-in successfully !")
         # Use returned URL to create a token
         token = mobileApp.fetch_token(token_url, authorization_response=redirect_response,include_client_id=True)


### PR DESCRIPTION
Implemented the mobile app only "Read to Earn" points. Confirmed working 😊

It would be better to cache the token, to avoid getting it every run. That would require extra error checking. Currently "reads" an article and stops if does not increase points. Might want to check points available for the offer, but the request to check status is more bandwidth then reading an article. To be more efficient, current implementation requires knowing the starting point balance, so going first enables that too.

Issue: ReadToEarn function must be called before DailySet, PunchCards,  MorePromotions. I am missing something to allow it to run after them. I get a `[ERROR] JavascriptException: Message: javascript error: dashboard is not defined` if run it after. 

Request: I would like a switch to load/save the config files and session data from the current working directory versus the python file directory. Currently I use sed in my docker build, but a runtime switch would be nicer. @cal4 is refactoring and putting all the file path calls in one function. Perhaps after that, someone could add a switch. I added it to the To Do list and crossed off Read To Earn. 

seds:
```
sed -i 's/Path(__file__).resolve().parent/Path.cwd()/g' main.py
sed -i 's/currentPath.parent.parent/Path.cwd()/g' src/browser.py 
```