### PR TITLE
Try/Except around crashing call

### DIFF
--- a/src/searches.py
+++ b/src/searches.py
@@ -138,7 +138,7 @@ class Searches:
                 searchbar = self.browser.utils.waitUntilVisible(
                     By.ID, "sb_form_q", timeToWait=20
                 )
-            catch:
+            except:
                 logging.debug('Exception in: searchbar = self.browser.utils.waitUntilVisible')
                 continue
             

--- a/src/searches.py
+++ b/src/searches.py
@@ -129,10 +129,14 @@ class Searches:
         logging.debug(f"passedInTerm={passedInTerm}")
 
         for i in range(self.maxAttempts):
-            searchbar = self.browser.utils.waitUntilVisible(
-                By.ID, "sb_form_q", timeToWait=20
-            )
-
+            try:
+                searchbar = self.browser.utils.waitUntilVisible(
+                    By.ID, "sb_form_q", timeToWait=20
+                )
+            catch:
+                logging.debug('Exception in: searchbar = self.browser.utils.waitUntilVisible')
+                continue
+            
             for _ in range(100):
                 searchbar.clear()
                 term = next(termsCycle)


### PR DESCRIPTION
This call timing-out caused an crash, so I wrapped in a try/catch. Perhaps there is a better way. 

```
selenium.common.exceptions.TimeoutException: Message: timeout: Timed out receiving message from renderer: 300.000
  (Session info: chrome=126.0.6478.126)
```