### PR TITLE
Add command line option to do either mobile or desktop search only

### DIFF
--- a/main.py
+++ b/main.py
@@ -252,7 +252,7 @@ def runReporter(currentBrowserUtil, runInfo):
         pass
 
 
-def desktopSearch(currentAccount, args, startingPoints, accountPointsCounter):
+def desktopSearch(currentAccount, args, accountPointsCounter):
     with Browser(mobile=False, account=currentAccount, args=args) as desktopBrowser:
         utils = desktopBrowser.utils
         Login(desktopBrowser, args).login()
@@ -295,10 +295,11 @@ def desktopSearch(currentAccount, args, startingPoints, accountPointsCounter):
 
     return accountPointsCounter
 
-def mobileSearch(currentAccount, args, startingPoints, accountPointsCounter):
+def mobileSearch(currentAccount, args, accountPointsCounter):
     with Browser(mobile=True, account=currentAccount, args=args) as mobileBrowser:
         utils = mobileBrowser.utils
         Login(mobileBrowser, args).login()
+        startingPoints = utils.getAccountPoints()
         with Searches(mobileBrowser) as searches:
             searches.bingSearches()
 
@@ -327,17 +328,15 @@ def executeBot(currentAccount: Account, args: argparse.Namespace):
 
     # noinspection PyUnusedLocal
     accountPointsCounter: int | None = None
-    # noinspection PyUnusedLocal
-    startingPoints: int | None = None
 
     if args.searchtype == "desktop":
-        accountPointsCounter = desktopSearch(currentAccount, args, startingPoints, accountPointsCounter)
+        accountPointsCounter = desktopSearch(currentAccount, args, accountPointsCounter)
     elif args.searchtype == "mobile":
-        accountPointsCounter = mobileSearch(currentAccount, args, startingPoints, accountPointsCounter)
+        accountPointsCounter = mobileSearch(currentAccount, args, accountPointsCounter)
     else:
-        accountPointsCounter = desktopSearch(currentAccount, args, startingPoints, accountPointsCounter)
+        accountPointsCounter = desktopSearch(currentAccount, args, accountPointsCounter)
         # The startingPoints for the consecutive run will be the previous accountPointsCounter, just to be clear
-        accountPointsCounter = mobileSearch(currentAccount, args, accountPointsCounter, accountPointsCounter)
+        accountPointsCounter = mobileSearch(currentAccount, args, accountPointsCounter)
 
     return accountPointsCounter
 

--- a/main.py
+++ b/main.py
@@ -158,6 +158,13 @@ def argumentParser() -> argparse.Namespace:
         action="store_true",
         help="Optional: Disable Apprise, overrides config.yaml, useful when developing",
     )
+    parser.add_argument(
+        "-t",
+        "--searchtype",
+        type=str,
+        default=None,
+        help="Optional: Set to only search in either desktop or mobile (ex: 'desktop' or 'mobile')"
+    )
     return parser.parse_args()
 
 
@@ -201,17 +208,51 @@ class AppriseSummary(Enum):
     on_error = auto()
     never = auto()
 
+# A bit hard coded for the passing over the info and might not be clear when reading the code about what runInfo is
+def runReporter(currentBrowserUtil, runInfo):
+    logging.info(
+        f"[POINTS] You have earned {currentBrowserUtil.formatNumber(runInfo['accountPointsCounter'] - runInfo['startingPoints'])} points this run !"
+    )
+    logging.info(
+        f"[POINTS] You are now at {currentBrowserUtil.formatNumber(runInfo['accountPointsCounter'])} points !"
+    )
+    appriseSummary = AppriseSummary[
+        currentBrowserUtil.config.get("apprise", {}).get("summary", AppriseSummary.always.name)
+    ]
+    if appriseSummary == AppriseSummary.always:
+        goalNotifier = ""
+        if runInfo['goalPoints'] > 0:
+            logging.info(
+                f"[POINTS] You are now at {(currentBrowserUtil.formatNumber((runInfo['accountPointsCounter'] / runInfo['goalPoints']) * 100))}% of your "
+                f"goal ({runInfo['goalTitle']}) !"
+            )
+            goalNotifier = (
+                f"🎯 Goal reached: {(currentBrowserUtil.formatNumber((runInfo['accountPointsCounter'] / runInfo['goalPoints']) * 100))}%"
+                f" ({runInfo['goalTitle']})"
+            )
 
-def executeBot(currentAccount: Account, args: argparse.Namespace):
-    logging.info(f"********************{currentAccount.username}********************")
+        Utils.sendNotification(
+            "Daily Points Update",
+            "\n".join(
+                [
+                    f"👤 Account: {runInfo['currentAccount'].username}",
+                    f"⭐️ Points earned today: {currentBrowserUtil.formatNumber(runInfo['accountPointsCounter'] - runInfo['startingPoints'])}",
+                    f"💰 Total points: {currentBrowserUtil.formatNumber(runInfo['accountPointsCounter'])}",
+                    goalNotifier,
+                ]
+            ),
+        )
+    elif appriseSummary == AppriseSummary.on_error:
+        if runInfo['remainingSearches'].getTotal() > 0:
+            Utils.sendNotification(
+                "Error: remaining searches",
+                f"account username: {runInfo['currentAccount'].username}, {runInfo['remainingSearches']}",
+            )
+    elif appriseSummary == AppriseSummary.never:
+        pass
 
-    # noinspection PyUnusedLocal
-    accountPointsCounter: int | None = None
-    # noinspection PyUnusedLocal
-    remainingSearches: RemainingSearches | None = None
-    # noinspection PyUnusedLocal
-    startingPoints: int | None = None
 
+def desktopSearch(currentAccount, args, startingPoints, accountPointsCounter):
     with Browser(mobile=False, account=currentAccount, args=args) as desktopBrowser:
         utils = desktopBrowser.utils
         Login(desktopBrowser, args).login()
@@ -239,8 +280,22 @@ def executeBot(currentAccount: Account, args: argparse.Namespace):
         # noinspection PyUnusedLocal
         accountPointsCounter = utils.getAccountPoints()
 
-    time.sleep(7.5)  # give time for browser to close, probably can be more fine-tuned
+        # Hash everything into a dictionary and send it over to the runReporter
+        runInfo = {
+            "currentAccount": currentAccount,
+            "startingPoints": startingPoints,
+            "accountPointsCounter": accountPointsCounter,
+            "remainingSearches": remainingSearches,
+            "goalPoints": goalPoints,
+            "goalTitle": goalTitle,
+        }
+        runReporter(utils, runInfo)
+    
+    time.sleep(7.5)
 
+    return accountPointsCounter
+
+def mobileSearch(currentAccount, args, startingPoints, accountPointsCounter):
     with Browser(mobile=True, account=currentAccount, args=args) as mobileBrowser:
         utils = mobileBrowser.utils
         Login(mobileBrowser, args).login()
@@ -253,46 +308,36 @@ def executeBot(currentAccount: Account, args: argparse.Namespace):
         remainingSearches = mobileBrowser.getRemainingSearches(desktopAndMobile=True)
         accountPointsCounter = utils.getAccountPoints()
 
-    logging.info(
-        f"[POINTS] You have earned {utils.formatNumber(accountPointsCounter - startingPoints)} points this run !"
-    )
-    logging.info(
-        f"[POINTS] You are now at {utils.formatNumber(accountPointsCounter)} points !"
-    )
-    appriseSummary = AppriseSummary[
-        utils.config.get("apprise", {}).get("summary", AppriseSummary.always.name)
-    ]
-    if appriseSummary == AppriseSummary.always:
-        goalNotifier = ""
-        if goalPoints > 0:
-            logging.info(
-                f"[POINTS] You are now at {(utils.formatNumber((accountPointsCounter / goalPoints) * 100))}% of your "
-                f"goal ({goalTitle}) !"
-            )
-            goalNotifier = (
-                f"🎯 Goal reached: {(utils.formatNumber((accountPointsCounter / goalPoints) * 100))}%"
-                f" ({goalTitle})"
-            )
+        # Hash everything into a dictionary and send it over to the runReporter
+        runInfo = {
+            "currentAccount": currentAccount,
+            "startingPoints": startingPoints,
+            "accountPointsCounter": accountPointsCounter,
+            "remainingSearches": remainingSearches,
+            "goalPoints": goalPoints,
+            "goalTitle": goalTitle,
+        }
+        runReporter(utils, runInfo)
 
-        Utils.sendNotification(
-            "Daily Points Update",
-            "\n".join(
-                [
-                    f"👤 Account: {currentAccount.username}",
-                    f"⭐️ Points earned today: {utils.formatNumber(accountPointsCounter - startingPoints)}",
-                    f"💰 Total points: {utils.formatNumber(accountPointsCounter)}",
-                    goalNotifier,
-                ]
-            ),
-        )
-    elif appriseSummary == AppriseSummary.on_error:
-        if remainingSearches.getTotal() > 0:
-            Utils.sendNotification(
-                "Error: remaining searches",
-                f"account username: {currentAccount.username}, {remainingSearches}",
-            )
-    elif appriseSummary == AppriseSummary.never:
-        pass
+    time.sleep(7.5)
+    return accountPointsCounter
+
+def executeBot(currentAccount: Account, args: argparse.Namespace):
+    logging.info(f"********************{currentAccount.username}********************")
+
+    # noinspection PyUnusedLocal
+    accountPointsCounter: int | None = None
+    # noinspection PyUnusedLocal
+    startingPoints: int | None = None
+
+    if args.searchtype == "desktop":
+        accountPointsCounter = desktopSearch(currentAccount, args, startingPoints, accountPointsCounter)
+    elif args.searchtype == "mobile":
+        accountPointsCounter = mobileSearch(currentAccount, args, startingPoints, accountPointsCounter)
+    else:
+        accountPointsCounter = desktopSearch(currentAccount, args, startingPoints, accountPointsCounter)
+        # The startingPoints for the consecutive run will be the previous accountPointsCounter, just to be clear
+        accountPointsCounter = mobileSearch(currentAccount, args, accountPointsCounter, accountPointsCounter)
 
     return accountPointsCounter
 


### PR DESCRIPTION
Added command line option for user to do searches only with desktop browser or mobile browser. Default behavior without setting the command line option is running both. I removed the random pauses before and after sleep because I think it is redundant when we already have delays set in the Searches class but please do let me know if it vital for avoiding suspicions. I also moved the step for reading articles into mobile searches to split up the tasks a bit. I'll mark this as a draft for now since I'm still testing and want to touch up logging a bit but please do leave suggestions and feedback :smiley: 

Edit: Now updated to be more in line with the existing code in the `develop` branch. Please disregard some of the statements above.