### PR TITLE
fixed Read to Earn country

### DIFF
--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -28,7 +28,7 @@ class ReadToEarn:
     def completeReadToEarn(self,startingPoints):
         
         logging.info("[READ TO EARN] " + "Trying to complete Read to Earn...")
-           
+        
         accountName = self.browser.username
         
         # Should Really Cache Token and load it in.
@@ -61,14 +61,15 @@ class ReadToEarn:
         
         # json data to confirm an article is read
         json_data = {
-            'amount': 1,
-            'country': 'us',
-            'id': 1,
-            'type': 101,
-            'attributes': {
-                'offerid': 'ENUS_readarticle3_30points',
-                },
-            }
+            "amount": 1,
+            # "country": "us",
+            "country": self.browser.localeGeo.lower(),
+            "id": 1,
+            "type": 101,
+            "attributes": {
+                "offerid": "ENUS_readarticle3_30points",
+            },
+        }
 
         balance = startingPoints
         # 10 is the most articles you can read. Sleep time is a guess, not tuned


### PR DESCRIPTION
By default the country is always US and if you are not there will set you on a permanent trip.

Used the solution proposed here https://github.com/klept0/MS-Rewards-Farmer/issues/141 by @weltonbraga 