### PR TITLE
Add support for automatic handling of logins with 2FA and for passwordless setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Support for automatic handling of time-based one-time password authentication
+
 ## [0.2.1] - 2024-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for automatic handling of time-based one-time password authentication
+- Support for automatic handling of logins with 2FA and for passwordless setups:
+  - Passwordless login is supported in both visible and headless mode by displaying the code that the user has to select on their phone in the terminal window
+  - 2FA login with TOTPs is supported in both visible and headless mode by allowing the user to provide their TOTP key in `accounts.json` which automatically generates the one time password
+  - 2FA login with device-based authentication is supported in theory, BUT doesn't currently work as the undetected chromedriver for some reason does not receive the confirmation signal after the user approves the login
 
 ## [0.2.1] - 2024-08-13
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@
 
 4. Edit the `accounts.json.sample` with your accounts credentials and rename it by removing `.sample` at the end.
 
+   The "totp" field is not mandatory, only enter your TOTP key if you use it for 2FA (if ommitting, don't keep
+   it as an empty string, remove the line completely).
+
    The "proxy" field is not mandatory, you can omit it if you don't want to use proxy (don't keep it as an empty string,
    remove the line completely).
 
@@ -54,16 +57,18 @@
 
    ```json
    [
-     {
-       "username": "Your Email 1",
-       "password": "Your Password 1",
-       "proxy": "http://user:pass@host1:port"
-     },
-     {
-       "username": "Your Email 2",
-       "password": "Your Password 2",
-       "proxy": "http://user:pass@host2:port"
-     }
+    {
+        "username": "Your Email 1",
+        "password": "Your Password 1",
+        "totp": "0123 4567 89ab cdef",
+        "proxy": "http://user:pass@host1:port"
+    },
+    {
+        "username": "Your Email 2",
+        "password": "Your Password 2",
+        "totp": "0123 4567 89ab cdef",
+        "proxy": "http://user:pass@host2:port"
+    }
    ]
    ```
 

--- a/accounts.json.sample
+++ b/accounts.json.sample
@@ -2,11 +2,13 @@
     {
         "username": "Your Email 1",
         "password": "Your Password 1",
+        "totp": "0123 4567 89ab cdef",
         "proxy": "http://user:pass@host1:port"
     },
     {
         "username": "Your Email 2",
         "password": "Your Password 2",
+        "totp": "0123 4567 89ab cdef",
         "proxy": "http://user:pass@host2:port"
     }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyyaml~=6.0.1
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 requests-oauthlib
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+pyotp

--- a/src/account.py
+++ b/src/account.py
@@ -5,4 +5,5 @@ from dataclasses import dataclass
 class Account:
     username: str
     password: str
+    totp: str | None = None
     proxy: str | None = None

--- a/src/browser.py
+++ b/src/browser.py
@@ -40,6 +40,7 @@ class Browser:
         self.headless = not args.visible
         self.username = account.username
         self.password = account.password
+        self.totp = account.totp
         self.localeLang, self.localeGeo = self.getCCodeLang(args.lang, args.geo)
         self.proxy = None
         if args.proxy:


### PR DESCRIPTION
Pull request to add support of (almost) all methods of signing into a Microsoft account.

Specifically support for the following methods has been added:

- **Passwordless login**, for which the user only enters their email, then is prompted to enter a specific code on their phone. This is supported in both visible and headless mode by displaying the code that the user has to select on their phone in the console window.
- **2FA login with TOTPs**, for which is user has to enter a one-time password in addition to their login details. The user may now store their TOTP key in `accounts.json`, which will then automatically generate the one-time password and submit it, working in both visible and headless mode. If the key is not provided, as fallback the user may still manually put in the OTP. This is only possible in visible mode.

Additionally, another possible method of logging in is 2FA login with external device authentication, for which the user, after putting in their password, has to confirm the login with the mobile app. This is supported in theory BUT doesn't currently work as the undetected chromedriver for some reason does not receive the confirmation signal after the user approves the login, and does progress with the login.