### PR TITLE
Add apprise notification on login with phone code

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,8 @@ apprise:
       ignore-safeguard-info: True
     uncaught-exception:
       enabled: True # True or False
+    login-code:
+      enabled: True # True or False
   summary: ON_ERROR
 default:
   geolocation: US # Replace with your country code https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2

--- a/src/login.py
+++ b/src/login.py
@@ -13,7 +13,7 @@ from selenium.webdriver.common.by import By
 from undetected_chromedriver import Chrome
 
 from src.browser import Browser
-from src.utils import sendNotification
+from src.utils import sendNotification, CONFIG
 
 
 class Login:
@@ -102,8 +102,14 @@ class Login:
                 "[LOGIN] Confirm your login with code %s on your phone (you have one minute)!\a",
                 codeField.text,
             )
-            sendNotification(
-                f"Confirm your login on your phone", f"Code: {codeField.text} (expires in 1 minute)")
+            if (
+                    CONFIG.get("apprise")
+                            .get("notify")
+                            .get("login-code")
+                            .get("enabled")
+            ):
+                sendNotification(
+                    f"Confirm your login on your phone", f"Code: {codeField.text} (expires in 1 minute)")
             self.utils.waitUntilVisible(By.NAME, "kmsiForm", 60)
             logging.info("[LOGIN] Successfully verified!")
         else:
@@ -143,8 +149,14 @@ class Login:
                     " one minute)!\a",
                     codeField.text,
                 )
-                sendNotification(
-                    f"Confirm your login on your phone", f"Code: {codeField.text} (expires in 1 minute)")
+                if (
+                        CONFIG.get("apprise")
+                                .get("notify")
+                                .get("login-code")
+                                .get("enabled")
+                ):
+                    sendNotification(
+                        f"Confirm your login on your phone", f"Code: {codeField.text} (expires in 1 minute)")
                 self.utils.waitUntilVisible(By.NAME, "kmsiForm", 60)
                 logging.info("[LOGIN] Successfully verified!")
 

--- a/src/login.py
+++ b/src/login.py
@@ -13,6 +13,7 @@ from selenium.webdriver.common.by import By
 from undetected_chromedriver import Chrome
 
 from src.browser import Browser
+from src.utils import sendNotification
 
 
 class Login:
@@ -101,6 +102,8 @@ class Login:
                 "[LOGIN] Confirm your login with code %s on your phone (you have one minute)!\a",
                 codeField.text,
             )
+            sendNotification(
+                f"Confirm your login on your phone", f"Code: {codeField.text} (expires in 1 minute)")
             self.utils.waitUntilVisible(By.NAME, "kmsiForm", 60)
             logging.info("[LOGIN] Successfully verified!")
         else:
@@ -140,6 +143,8 @@ class Login:
                     " one minute)!\a",
                     codeField.text,
                 )
+                sendNotification(
+                    f"Confirm your login on your phone", f"Code: {codeField.text} (expires in 1 minute)")
                 self.utils.waitUntilVisible(By.NAME, "kmsiForm", 60)
                 logging.info("[LOGIN] Successfully verified!")
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -37,6 +37,7 @@ DEFAULT_CONFIG: MappingProxyType = MappingProxyType(
             "notify": {
                 "incomplete-activity": {"enabled": True, "ignore-safeguard-info": True},
                 "uncaught-exception": {"enabled": True},
+                "login-code": {"enabled": True},
             },
             "summary": "ON_ERROR",
         },


### PR DESCRIPTION
Send an Apprise notification when receiving a code to validate with Microsoft Authentificator.

This allows users to run the bot in the background, even if they aren't connected/their session expires.
Also convenient if you're not paying attention to the terminal and have phone notifications muted.

Example:
![image](https://github.com/user-attachments/assets/8b3bb2b0-74fe-4f97-b5c1-17766fe3dc0b)
