### PR TITLE
fix (browser): detect default language

### DIFF
--- a/src/browser.py
+++ b/src/browser.py
@@ -36,7 +36,7 @@ class Browser:
         self.email = account.email
         self.password = account.password
         self.totp = account.get('totp')
-        self.localeLang, self.localeGeo = self.getLanguageCountry(CONFIG.browser.language, CONFIG.browser.geolocation)
+        self.localeLang, self.localeGeo = self.getLanguageCountry()
         self.proxy = CONFIG.browser.proxy
         if not self.proxy and account.get('proxy'):
             self.proxy = account.proxy
@@ -217,12 +217,9 @@ class Browser:
         return sessionsDir
 
     @staticmethod
-    def getLanguageCountry(language: str, country: str) -> tuple[str, str]:
-        if not country:
-            country = CONFIG.browser.geolocation
-
-        if not language:
-            country = CONFIG.browser.language
+    def getLanguageCountry() -> tuple[str, str]:
+        country = CONFIG.browser.geolocation
+        language = CONFIG.browser.language
 
         if not language or not country:
             currentLocale = locale.getlocale()

--- a/src/utils.py
+++ b/src/utils.py
@@ -170,8 +170,8 @@ DEFAULT_CONFIG: Config = Config(
             'urls': []
         },
         'browser': {
-            'geolocation': 'US',
-            'language': 'en',
+            'geolocation': None,
+            'language': None,
             'visible': False,
             'proxy': None
         },


### PR DESCRIPTION
This PR fixes a bug introduced in #248:

Because the default config included a language and country for the browser, the function [getLanguageCountry](https://github.com/klept0/MS-Rewards-Farmer/blob/1671870923e3c5b5a58cadc862eacd8929bbadcf/src/browser.py#L220) was completely useless and always returned the configuration settings.

This sets the default country and language to `None`, so this function can work as expected.