### PR TITLE
Feat/better script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,16 +176,17 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 
+# MacOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+
 # Custom rules (everything added below won't be overridden by 'Generate .gitignore File' if you use 'Update' option)
 
-accounts.json
-sessions
-logs
-runbot.bat
-.DS_Store
-/google_trends.dat
-/google_trends.dir
-/google_trends.bak
-/config-private.yaml
-mypy.ini
+sessions/
+logs/
+/google_trends.*
 config.yaml
+MsReward.xml

--- a/MS_reward.bat
+++ b/MS_reward.bat
@@ -1,7 +1,0 @@
-@echo off
-
-set CURRENT_DIR=%~dp0
-
-cd /d "%CURRENT_DIR%"
-
-python main.py -v

--- a/MsReward.ps1
+++ b/MsReward.ps1
@@ -12,7 +12,7 @@
 
 param (
     [switch]$help = $false,
-    [switch]$skipUpdate = $false,
+    [switch]$update = $false,
     [switch]$noCacheDelete = $false,
     [int]$maxRetries = 5,
     [string]$arguments = "",
@@ -29,11 +29,11 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 Set-Location $scriptDir
 
 if ($help) {
-    Write-Host "Usage: .\MS_reward.ps1 [-help] [-skipUpdate] [-maxRetries <int>] [-arguments <string>] [-pythonExecutablePath <string>] [-scriptName <string>] [-cacheFolder <string>] [-logColor <string>]"
+    Write-Host "Usage: .\MS_reward.ps1 [-help] [-update] [-maxRetries <int>] [-arguments <string>] [-pythonExecutablePath <string>] [-scriptName <string>] [-cacheFolder <string>] [-logColor <string>]"
     Write-Host ""
     Write-Host "Options:"
     Write-Host "  -help                 Display this help message."
-    Write-Host "  -skipUpdate           Skip the script update."
+    Write-Host "  -update               Update the script if a new version is available."
     Write-Host "  -noCacheDelete        Do not delete the cache folder if the script fails."
     Write-Host "  -maxRetries <int>     Maximum number of retries if the script fails (default: 5)."
     Write-Host "  -arguments <string>   Arguments to pass to the main script."
@@ -51,7 +51,7 @@ if ($help) {
 
 $updated = $false
 
-if ((-not $skipUpdate) -and (Test-Path .git) -and (Get-Command git -ErrorAction SilentlyContinue)) {
+if ($update -and (Test-Path .git) -and (Get-Command git -ErrorAction SilentlyContinue)) {
     $gitOutput = & git pull --ff-only
     if ($LastExitCode -eq 0) {
         if ($gitOutput -match "Already up to date.") {

--- a/MsReward.ps1
+++ b/MsReward.ps1
@@ -5,6 +5,9 @@
 # and retry if it fails, while cleaning every error-prone elements (sessions,
 # orphan chrome instances, etc.).
 
+# Use the `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser` command to allow
+# script execution in PowerShell without confirmation each time.
+
 
 # --------------------------- Script initialization ----------------------------
 # Set the script directory as the working directory and define the script

--- a/MsReward.ps1
+++ b/MsReward.ps1
@@ -17,7 +17,7 @@ param (
     [switch]$help = $false,
     [switch]$update = $false,
     [switch]$noCacheDelete = $false,
-    [int]$maxRetries = 5,
+    [int]$maxRetries = 3,
     [string]$arguments = "",
     [string]$pythonPath = "",
     [string]$scriptName = "main.py",

--- a/MsReward.ps1
+++ b/MsReward.ps1
@@ -1,0 +1,141 @@
+# ----------------------------- Script description -----------------------------
+# This script is a wrapper for the "MS Rewards Farmer" python script, which is
+# a tool to automate the Microsoft Rewards daily tasks. The script will try to
+# update the main script, detect the Python installation, run the main script
+# and retry if it fails, while cleaning every error-prone elements (sessions,
+# orphan chrome instances, etc.).
+
+
+# --------------------------- Script initialization ----------------------------
+# Set the script directory as the working directory and define the script
+# parameters
+
+param (
+    [switch]$help = $false,
+    [switch]$skipUpdate = $false,
+    [int]$maxRetries = 5,
+    [string]$arguments = "",
+    [string]$pythonPath = "",
+    [string]$scriptName = "main.py",
+    [string]$cacheFolder = ".\sessions",
+    [string]$logColor = "Yellow"
+)
+
+$name = "MS Rewards Farmer"
+$startTime = Get-Date
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location $scriptDir
+
+if ($help) {
+    Write-Host "Usage: .\MS_reward.ps1 [-help] [-skipUpdate] [-maxRetries <int>] [-arguments <string>] [-pythonExecutablePath <string>] [-scriptName <string>] [-cacheFolder <string>] [-logColor <string>]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -help                 Display this help message."
+    Write-Host "  -skipUpdate           Skip the script update."
+    Write-Host "  -maxRetries <int>     Maximum number of retries if the script fails (default: 5)."
+    Write-Host "  -arguments <string>   Arguments to pass to the main script."
+    Write-Host "  -pythonPath <string>  Path to the Python executable."
+    Write-Host "  -scriptName <string>  Name of the main script."
+    Write-Host "  -cacheFolder <string> Folder to store the sessions."
+    Write-Host "  -logColor <string>    Color of the log messages (default: Yellow)."
+    exit 0
+}
+
+
+# ------------------------------- Script update --------------------------------
+# Try to update the script if git is available and the script is in a
+# git repository
+
+$updated = $false
+
+if ((-not $skipUpdate) -and (Test-Path .git) -and (Get-Command git -ErrorAction SilentlyContinue)) {
+    $gitOutput = & git pull --ff-only
+    if ($LastExitCode -eq 0) {
+        if ($gitOutput -match "Already up to date.") {
+            Write-Host "> $name is already up-to-date" -ForegroundColor $logColor
+        } else {
+            $updated = $true
+            Write-Host "> $name updated successfully" -ForegroundColor $logColor
+        }
+    } else {
+        Write-Host "> Cannot automatically update $name - please update it manually." -ForegroundColor $logColor
+    }
+}
+
+
+# ----------------------- Python installation detection ------------------------
+# Try to detect the Python installation or virtual environments
+
+# If no virtual environment Python executable was provided, try to find a
+# virtual environment Python executable
+if (-not $pythonPath) {
+    $pythonPath = (Get-ChildItem -Path .\ -Recurse -Filter python.exe | Where-Object { $_.FullName -match "Scripts\\python.exe" }).FullName | Select-Object -First 1
+}
+
+# If no virtual environment Python executable was found, try to find the py
+# launcher
+if (-not $pythonPath) {
+    $pythonPath = (Get-Command py -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)
+}
+
+# If no virtual environment Python executable or py launcher was found, try to
+# find the system Python
+if (-not $pythonPath) {
+    $pythonPath = (Get-Command python -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)
+}
+
+# If no Python executable was found, exit with an error
+if (-not $pythonPath) {
+    Write-Host "> Python executable not found. Please install Python." -ForegroundColor $logColor
+    exit 1
+}
+
+
+# ------------------------- Python dependencies update -------------------------
+# Try to update the Python dependencies if the script was updated
+
+if ($updated) {
+    & $pythonPath -m pip install -r requirements.txt --upgrade
+    if ($LastExitCode -eq 0) {
+        Write-Host "> Python dependencies updated successfully" -ForegroundColor $logColor
+    } else {
+        Write-Host "> Cannot update Python dependencies - please update them manually." -ForegroundColor $logColor
+    }
+}
+
+
+# --------------------------------- Script run ---------------------------------
+# Try to run the script and retry if it fails, while cleaning every error-prone
+# elements (sesions, orphan chrome instances, etc.)
+
+function Invoke-Farmer {
+    for ($i = 1; $i -le $maxRetries; $i++) {
+        if ($arguments) {
+            & $pythonPath $scriptName $arguments
+        } else {
+            & $pythonPath $scriptName
+        }
+        if ($LastExitCode -eq 0) {
+            Write-Host "> $name completed (Attempt $i/$maxRetries)." -ForegroundColor $logColor
+            exit 0
+        }
+        Write-Host "> $name failed (Attempt $i/$maxRetries) with exit code $LastExitCode." -ForegroundColor $logColor
+        Stop-Process -Name "undetected_chromedriver" -ErrorAction SilentlyContinue
+        Get-Process -Name "chrome" -ErrorAction SilentlyContinue | Where-Object { $_.StartTime -gt $startTime } | Stop-Process -ErrorAction SilentlyContinue
+    }
+}
+
+Invoke-Farmer
+
+Write-Host "> All $name runs failed ($maxRetries/$maxRetries). Removing cache and re-trying..." -ForegroundColor $logColor
+
+if (Test-Path "$cacheFolder") {
+    Remove-Item -Recurse -Force "$cacheFolder" -ErrorAction SilentlyContinue
+}
+
+Invoke-Farmer
+
+Write-Host "> All $name runs failed ($maxRetries/$maxRetries). Exiting with error." -ForegroundColor $logColor
+
+exit 1

--- a/MsReward.ps1
+++ b/MsReward.ps1
@@ -13,6 +13,7 @@
 param (
     [switch]$help = $false,
     [switch]$skipUpdate = $false,
+    [switch]$noCacheDelete = $false,
     [int]$maxRetries = 5,
     [string]$arguments = "",
     [string]$pythonPath = "",
@@ -33,6 +34,7 @@ if ($help) {
     Write-Host "Options:"
     Write-Host "  -help                 Display this help message."
     Write-Host "  -skipUpdate           Skip the script update."
+    Write-Host "  -noCacheDelete        Do not delete the cache folder if the script fails."
     Write-Host "  -maxRetries <int>     Maximum number of retries if the script fails (default: 5)."
     Write-Host "  -arguments <string>   Arguments to pass to the main script."
     Write-Host "  -pythonPath <string>  Path to the Python executable."
@@ -129,13 +131,15 @@ function Invoke-Farmer {
 
 Invoke-Farmer
 
-Write-Host "> All $name runs failed ($maxRetries/$maxRetries). Removing cache and re-trying..." -ForegroundColor $logColor
+if (-not $noCacheDelete) {
+    Write-Host "> All $name runs failed ($maxRetries/$maxRetries). Removing cache and re-trying..." -ForegroundColor $logColor
 
-if (Test-Path "$cacheFolder") {
-    Remove-Item -Recurse -Force "$cacheFolder" -ErrorAction SilentlyContinue
+    if (Test-Path "$cacheFolder") {
+        Remove-Item -Recurse -Force "$cacheFolder" -ErrorAction SilentlyContinue
+    }
+
+    Invoke-Farmer
 }
-
-Invoke-Farmer
 
 Write-Host "> All $name runs failed ($maxRetries/$maxRetries). Exiting with error." -ForegroundColor $logColor
 

--- a/MsReward.ps1
+++ b/MsReward.ps1
@@ -91,6 +91,7 @@ if (-not $pythonPath) {
     exit 1
 }
 
+Write-Host "> Python executable found at $pythonPath" -ForegroundColor $logColor
 
 # ------------------------- Python dependencies update -------------------------
 # Try to update the Python dependencies if the script was updated

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@
 ## Installation
 
 1. Install requirements with the following command :
-
-   `pip install -r requirements.txt`
+   ```sh
+   pip install -r requirements.txt
+   ```
 
    Upgrade all required with the following command:
    `pip install --upgrade -r requirements.txt`
@@ -47,7 +48,7 @@
    and reboot your computer
 
 4. Run the script with the following arguments:
-   ```
+   ```sh
    python main.py -C
    ```
 
@@ -64,8 +65,14 @@
    the "apprise.urls" field is not mandatory, you can remove it if you don't want to get notifications.
 
 6. Run the script:
+   ```sh
+   python main.py
+   ```
 
-   `python main.py`
+   (Windows Only) You can also run the script wrapper that will detect your python installation
+   and re-run the script if it crashes using `.\MsReward.ps1` (`.\MsReward.ps1 -help` for more
+   information). To allow script execution without confirmation, use the following command:
+   `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser`.
 
 7. (Windows Only) You can set up automatic execution by generating a Task Scheduler XML file.
 

--- a/generate_task_xml.py
+++ b/generate_task_xml.py
@@ -85,7 +85,7 @@ xml_content = f"""<?xml version="1.0" encoding="UTF-16"?>
   <Actions Context="Author">
     <Exec>
       <Command>%windir%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe</Command>
-      <Arguments>-File "{script_path}"</Arguments>
+      <Arguments>-File "{script_path}" -ExecutionPolicy Bypass</Arguments>
       <WorkingDirectory>{script_dir}</WorkingDirectory>
     </Exec>
   </Actions>

--- a/generate_task_xml.py
+++ b/generate_task_xml.py
@@ -1,11 +1,12 @@
 import getpass
 import os
 import subprocess
-from datetime import datetime
+import datetime as dt
 from pathlib import Path
 
 # Get the directory of the script being run
 script_dir = Path(__file__).parent.resolve()
+script_path = script_dir / "MsReward.ps1"
 
 # Get the current user's name
 current_user = getpass.getuser()
@@ -39,36 +40,12 @@ if sid is None:
 
 computer_name = os.environ["COMPUTERNAME"]
 
-# Let the user choose between Miniconda and Anaconda
-print("Please choose your Python distribution:")
-print("1. Local (Windows system Python without virtual environment)")
-print("2. Anaconda")
-print("3. Miniconda")
-choice = input("Enter your choice (1, 2, or 3): ")
-
-if choice == "1":
-    command = f"{script_dir}\\MS_reward.bat"
-elif choice == "2":
-    base_path = f"C:\\Users\\{current_user}\\anaconda3"
-    command = f"{base_path}\\Scripts\\activate.bat {base_path} &amp;&amp; conda activate {{env_name}} &amp;&amp; {script_dir}\\MS_reward.bat"
-elif choice == "3":
-    base_path = f"C:\\Users\\{current_user}\\miniconda3"
-    command = f"{base_path}\\Scripts\\activate.bat {base_path} &amp;&amp; conda activate {{env_name}} &amp;&amp; {script_dir}\\MS_reward.bat"
-else:
-    print("Invalid choice, please rerun the script and choose 1, 2, or 3.")
-    exit(1)
-
-# Let the user enter the name of the environment they are using
-if choice in ["2", "3"]:
-    env_name = input("Please enter the name of the environment you are using: ")
-    command = command.format(env_name=env_name)
-
 xml_content = f"""<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
-    <Date>{datetime.utcnow().isoformat()}</Date>
+    <Date>{dt.datetime.now(dt.UTC).isoformat()}</Date>
     <Author>{computer_name}\\{current_user}</Author>
-    <URI>\\Custom\\MS reward</URI>
+    <URI>\\Custom\\MsReward</URI>
   </RegistrationInfo>
   <Triggers>
     <CalendarTrigger>
@@ -107,15 +84,15 @@ xml_content = f"""<?xml version="1.0" encoding="UTF-16"?>
   </Settings>
   <Actions Context="Author">
     <Exec>
-      <Command>%windir%\\System32\\cmd.exe</Command>
-      <Arguments>/K "{command}"</Arguments>
+      <Command>%windir%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe</Command>
+      <Arguments>-File "{script_path}"</Arguments>
       <WorkingDirectory>{script_dir}</WorkingDirectory>
     </Exec>
   </Actions>
 </Task>"""
 
 # Use the script directory as the output path
-output_path = script_dir / "MS_reward.xml"
+output_path = script_dir / "MsReward.xml"
 
 with open(output_path, "w", encoding="utf-16") as file:
     file.write(xml_content)


### PR DESCRIPTION
Replace the now reverted #262

Introduce a new script wrapper that can be used in - but not limited to - the Windows Task Scheduler.

Note that *program* here refers to the "MS Rewards Farmer" python script, and *script* refers to the powershell script that wraps the program.

- Use powershell instead of CMD (not a feature, but a breaking change)
- Automatically update the repo when using git if `-update` is used - not the default behavior because this might be unwanted
- Update program dependencies when updated
- Detect the correct Python environment
  - Python executable can be provided as parameter, it'll be validated to make sure it's a valid path
  - If not provided, try to find a python virtual environment (venv) or an anaconda/miniconda virtual environment (conda), whatever it's called.
  - If not found, try to find the `py` launcher.
  - If not found, try to find the `python` executable.
- Run the program, retry 3 times if it fails (can be changed with a parameter)
  - Each time it fails, kill all instances of `undetected_chromedriver` and all instances of chromes created **after** the script was executed.
- If the maximum number of retries has been reached, delete the `session` folder (can be disabled with a parameter) and restart the above step before finally giving up.
- Arguments can be passed to the program using the `-arguments` parameter.
- Other behaviours can be customized, use `MsReward.ps1 -help` to display them.