### PR TITLE
getLanguageCountry: fix AttributeError, removed dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ blinker==1.7.0 # prevents issues on newer versions
 numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
 ipapi~=1.0.4
 psutil
-pycountry~=24.6.1
 pyotp~=2.9.0
 pyyaml~=6.0.2
 requests-oauthlib~=2.0.0

--- a/src/browser.py
+++ b/src/browser.py
@@ -8,7 +8,6 @@ from types import TracebackType
 from typing import Any, Type
 
 import ipapi
-import pycountry
 import seleniumwire.undetected_chromedriver as webdriver
 import undetected_chromedriver
 from ipapi.exceptions import RateLimited
@@ -222,17 +221,9 @@ class Browser:
         language = CONFIG.browser.language
 
         if not language or not country:
-            currentLocale = locale.getlocale()
-            if not language:
-                with contextlib.suppress(ValueError):
-                    language = pycountry.languages.get(
-                        alpha_2=currentLocale[0].split("_")[0]
-                    ).alpha_2
-            if not country:
-                with contextlib.suppress(ValueError):
-                    country = pycountry.countries.get(
-                        alpha_2=currentLocale[0].split("_")[1]
-                    ).alpha_2
+            locale_info = locale.getlocale()
+            if locale_info[0]:
+                language, country = locale_info[0].split("_")
 
         if not language or not country:
             try:


### PR DESCRIPTION
Fixed a problem where the `pycountry` library didn't recognise the country/language code, and trying to get the `alpha_2` attribute caused an error, preventing the whome script from running.

I removed the use of `pycountry` altogether, as the language and country were obtained by searching the locale with `alpha_2`, then getting the `alpha_2` attribute - which seems completely useless, and could only cause problems from what I saw. I don't know if I'm right.

Asking for Cal's review, since he's the one who wrote the `getLanguageCountry` function in the first place.