### PR TITLE
Always log DEBUG level messages in the log file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,10 +44,10 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Copy and paste your error
+      label: Import the logs
       description: |
-        Run the program with -d argument (ex: python main.py -d) and, from the terminal that was running the farmer, 
-        copy and paste the log/error/bug here.
+        Paste the `logs/activity.log` file, or the `logs/activity-*.log` file containing the error.
+      placeholder: Don't write the logs here, just drag and drop the file here
     validations:
       required: true
   - type: textarea

--- a/main.py
+++ b/main.py
@@ -92,30 +92,29 @@ def setupLogging():
     _format = CONFIG.logging.format
     terminalHandler = logging.StreamHandler(sys.stdout)
     terminalHandler.setFormatter(ColoredFormatter(_format))
+    terminalHandler.setLevel(logging.getLevelName(CONFIG.logging.level.upper()))
 
     logs_directory = getProjectRoot() / "logs"
     logs_directory.mkdir(parents=True, exist_ok=True)
 
-    # so only our code is logged if level=logging.DEBUG or finer
-    logging.config.dictConfig(
-        {
+    fileHandler = handlers.TimedRotatingFileHandler(
+        logs_directory / "activity.log",
+        when="midnight",
+        backupCount=2,
+        encoding="utf-8",
+    )
+    fileHandler.namer = lambda name: name.replace('.log.', '-') + '.log'
+    fileHandler.setLevel(logging.DEBUG)
+
+    logging.config.dictConfig({
             "version": 1,
             "disable_existing_loggers": True,
-        }
-    )
+    })
+
     logging.basicConfig(
-        level=logging.getLevelName(CONFIG.logging.level.upper()),
+        level=logging.DEBUG,
         format=_format,
-        handlers=[
-            handlers.TimedRotatingFileHandler(
-                logs_directory / "activity.log",
-                when="midnight",
-                interval=1,
-                backupCount=2,
-                encoding="utf-8",
-            ),
-            terminalHandler,
-        ],
+        handlers=[fileHandler, terminalHandler],
         force=True,
     )
 


### PR DESCRIPTION
This should make troubleshooting easier.

- Always log in the log file at the `DEBUG` level, ignoring the user's configuration (which now only applies to the terminal)
- Renamed log files from `activity.log.date` to `activity-date.log`
- Updated the bug report form to encourage users to submit their entire log file, providing more context and making it easier to fix bugs.