### PR TITLE
add reset functionality to delete session files and kill chrome processes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
             (I have checked every bug report on GitHub)
           required: true
         - label: |
-            I've cleared the sessions folder.
+            I've ran the program with the -r argument.
           required: true
   - type: dropdown
     id: branch

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ accounts: # The accounts to use. You can put zero, one or an infinite number of 
 
 ```
 usage: main.py [-h] [-c CONFIG] [-C] [-v] [-l LANG] [-g GEO] [-em EMAIL] [-pw PASSWORD]
-               [-p PROXY] [-t {desktop,mobile,both}] [-da] [-d]
+               [-p PROXY] [-t {desktop,mobile,both}] [-da] [-d] [-r]
 
 A simple bot that uses Selenium to farm M$ Rewards in Python
 
@@ -202,6 +202,8 @@ options:
   -da, --disable-apprise
                         Disable Apprise notifications, useful when developing
   -d, --debug           Set the logging level to DEBUG
+  -r, --reset           Delete the session folder and temporary files and kill all chrome
+                        processes. Can help resolve issues.
 
 At least one account should be specified, either using command line arguments or a
 configuration file. All specified arguments will override the configuration file values

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apprise~=1.9.2
 blinker==1.7.0 # prevents issues on newer versions
 ipapi~=1.0.4
 numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
-psutil
+psutil~=7.0.0
 PyAutoGUI~=0.9.54
 pyotp~=2.9.0
 pyyaml~=6.0.2


### PR DESCRIPTION
This should make troubleshooting easier.

Adds a `--reset` parameter than, when used:
- Recursively deletes the `sessions` folder
- Deletes the files `google_trends.bak`, `google_trends.dat`, `google_trends.dir` `logs/previous_points_data.json`
- Kills all running chrome instances
- Exits 0