### PR TITLE
Fix google trends

### DIFF
--- a/src/searches.py
+++ b/src/searches.py
@@ -84,7 +84,7 @@ class Searches:
                     f"google_trends before load = {list(self.googleTrendsShelf.items())}"
                 )
                 trends = Trends()
-                trends = trends.trending_now(geo=CONFIG.browser.geolocation)[
+                trends = trends.trending_now(geo=self.browser.localeGeo)[
                     : desktopAndMobileRemaining.getTotal()
                 ]
                 for trend in trends:


### PR DESCRIPTION
Fix #280

The bot was using the config-based geolocation to get google trends instead of the determined-one (which uses the config-one if provided and determines it as a fallback).

The config-based one could be None if not provided, causing this error.