### PR TITLE
Fix activities that contains non-breakable spaces in their name

### DIFF
--- a/src/activities.py
+++ b/src/activities.py
@@ -158,7 +158,7 @@ class Activities:
                 # pyautogui.hotkey("alt", "f4") # Close Edge
                 return
             activityElement = self.browser.utils.waitUntilClickable(
-                By.XPATH, f'//*[contains(text(), "{activityTitle}")]', timeToWait=20
+                By.XPATH, f'//*[contains(text(), "{activity["title"]}")]', timeToWait=20
             )
             self.browser.utils.click(activityElement)
             self.browser.utils.switchToNewTab()


### PR DESCRIPTION
Some activities, in specific languages, contains nbsps (non-breakable spaces).

![image](https://github.com/user-attachments/assets/eb185e05-2b33-46f4-912e-c093ebda5599)

This prevents `completeActivity` to work normally, as `f'//*[contains(text(), "{activityTitle}")]'` is used to click on the card, and `activityTitle` corresponds to `activity['title'].replace("\u200b", "").replace("\xa0", " ")` (`\xa0`, the character representing a nbsp, is changed to a normal space), which causes the element search to return no results, raising a `TimeoutException`. This also mean that activities containing a zero-width space (`\u200b`) in their name are subject to the same bug.

This bug can easily be fixed by using `f'//*[contains(text(), "{activity["title"]}")]'` instead to search the card.

## Changed
- Use the non-formatted activity title in the activity XPATH search