### PR TITLE
Use direct activity link instead of clicking on card

### DIFF
--- a/main.py
+++ b/main.py
@@ -162,13 +162,13 @@ def executeBot(currentAccount):
             with Searches(desktopBrowser) as searches:
                 searches.bingSearches()
 
-            goalPoints = utils.getGoalPoints()
+            goalPoints = utils.getGoalPoints(True)
             goalTitle = utils.getGoalTitle()
 
             remainingSearches = desktopBrowser.getRemainingSearches(
                 desktopAndMobile=True
             )
-            accountPoints = utils.getAccountPoints()
+            accountPoints = utils.getAccountPoints(True)
 
     if CONFIG.search.type in ("mobile", "both", None):
         with Browser(mobile=True, account=currentAccount) as mobileBrowser:
@@ -183,13 +183,13 @@ def executeBot(currentAccount):
             with Searches(mobileBrowser) as searches:
                 searches.bingSearches()
 
-            goalPoints = utils.getGoalPoints()
+            goalPoints = utils.getGoalPoints(True)
             goalTitle = utils.getGoalTitle()
 
             remainingSearches = mobileBrowser.getRemainingSearches(
                 desktopAndMobile=True
             )
-            accountPoints = utils.getAccountPoints()
+            accountPoints = utils.getAccountPoints(True)
 
     logging.info(
         f"[POINTS] You have earned {formatNumber(accountPoints - startingPoints)} points this run !"

--- a/main.py
+++ b/main.py
@@ -139,7 +139,7 @@ class AppriseSummary(Enum):
 
 
 def executeBot(currentAccount):
-    logging.info(f"********************{currentAccount.email}********************")
+    logging.info(f"******************** {currentAccount.email} ********************")
 
     startingPoints: int | None = None
     accountPoints: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ blinker==1.7.0 # prevents issues on newer versions
 ipapi~=1.0.4
 numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
 psutil~=7.0.0
-PyAutoGUI~=0.9.54
 pyotp~=2.9.0
 pyyaml~=6.0.2
 requests-oauthlib~=2.0.0

--- a/src/activities.py
+++ b/src/activities.py
@@ -183,7 +183,7 @@ class Activities:
         # todo Send one email for all accounts?
         if CONFIG.get("apprise.notify.incomplete-activity"):  # todo Use fancy new way
             incompleteActivities: list[str] = []
-            for activity in self.browser.utils.getActivities():  # Have to refresh
+            for activity in self.browser.utils.getActivities(True):  # Have to refresh
                 activityTitle = cleanupActivityTitle(activity["title"])
                 if (
                     activityTitle not in CONFIG.activities.ignore

--- a/src/browser.py
+++ b/src/browser.py
@@ -265,7 +265,7 @@ class Browser:
         if PREFER_BING_INFO:
             bingInfo = self.utils.getBingInfo()
         else:
-            bingInfo = self.utils.getDashboardData()
+            bingInfo = self.utils.getDashboardData(True)
         searchPoints = 1
         if PREFER_BING_INFO:
             counters = bingInfo["flyoutResult"]["userStatus"]["counters"]

--- a/src/browser.py
+++ b/src/browser.py
@@ -181,13 +181,6 @@ class Browser:
                 "screenHeight": screenHeight,
                 "positionX": 0,
                 "positionY": 0,
-                "viewport": {
-                    "x": 0,
-                    "y": 0,
-                    "width": deviceWidth,
-                    "height": deviceHeight,
-                    "scale": 1,
-                },
             },
         )
 

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -6,7 +6,6 @@ import time
 from requests_oauthlib import OAuth2Session
 
 from src.browser import Browser
-from .activities import Activities
 from .utils import makeRequestsSession, cooldown
 
 # todo Use constant naming style
@@ -25,7 +24,6 @@ class ReadToEarn:
     def __init__(self, browser: Browser):
         self.browser = browser
         self.webdriver = browser.webdriver
-        self.activities = Activities(browser)
 
     def completeReadToEarn(self):
 
@@ -52,7 +50,7 @@ class ReadToEarn:
             time.sleep(1)
 
         logging.info("[READ TO EARN] Logged-in successfully !")
-        token = mobileApp.fetch_token(
+        mobileApp.fetch_token(
             token_url, authorization_response=redirect_response, include_client_id=True
         )
         # Do Daily Check in

--- a/src/searches.py
+++ b/src/searches.py
@@ -63,8 +63,6 @@ class Searches:
             f"[BING] Starting {self.browser.browserType.capitalize()} Edge Bing searches..."
         )
 
-        self.browser.utils.goToSearch()
-
         while True:
             desktopAndMobileRemaining = self.browser.getRemainingSearches(
                 desktopAndMobile=True
@@ -145,7 +143,7 @@ class Searches:
             sleep(1)
             searchbar.submit()
 
-            pointsAfter = self.browser.utils.getAccountPoints()
+            pointsAfter = self.browser.utils.getAccountPoints(True)
             if pointsBefore < pointsAfter:
                 del self.googleTrendsShelf[trend]
                 cooldown()

--- a/src/utils.py
+++ b/src/utils.py
@@ -285,33 +285,37 @@ class Utils:
 
         self.webdriver.switch_to.window(curr)
         time.sleep(0.5)
-        self.goToRewards()
+        self.goToRewards(True)
 
-    def goToRewards(self) -> None:
+    def goToRewards(self, forceRefresh=False) -> None:
+        if self.webdriver.current_url == REWARDS_URL and not forceRefresh:
+            return
         self.webdriver.get(REWARDS_URL)
         assert (
             self.webdriver.current_url == REWARDS_URL
         ), f"{self.webdriver.current_url} {REWARDS_URL}"
 
-    def goToSearch(self) -> None:
+    def goToSearch(self, forceRefresh=False) -> None:
+        if self.webdriver.current_url == SEARCH_URL and not forceRefresh:
+            return
         self.webdriver.get(SEARCH_URL)
 
     # Prefer getBingInfo if possible
-    def getDashboardData(self) -> dict:
-        self.goToRewards()
+    def getDashboardData(self, forceRefresh=False) -> dict:
+        self.goToRewards(forceRefresh)
         time.sleep(5)  # fixme Avoid busy wait (if this works)
         return self.webdriver.execute_script("return dashboard")
 
-    def getDailySetPromotions(self) -> list[dict]:
-        return self.getDashboardData()["dailySetPromotions"][
+    def getDailySetPromotions(self, forceRefresh=False) -> list[dict]:
+        return self.getDashboardData(forceRefresh)["dailySetPromotions"][
             date.today().strftime("%m/%d/%Y")
         ]
 
-    def getMorePromotions(self) -> list[dict]:
-        return self.getDashboardData()["morePromotions"]
+    def getMorePromotions(self, forceRefresh=False) -> list[dict]:
+        return self.getDashboardData(forceRefresh)["morePromotions"]
 
-    def getActivities(self) -> list[dict]:
-        return self.getDailySetPromotions() + self.getMorePromotions()
+    def getActivities(self, forceRefresh=False) -> list[dict]:
+        return self.getDailySetPromotions(forceRefresh) + self.getMorePromotions()
 
     # Not reliable
     def getBingInfo(self) -> Any:
@@ -340,20 +344,20 @@ class Utils:
             return True
         return False
 
-    def getAccountPoints(self) -> int:
+    def getAccountPoints(self, forceRefresh=False) -> int:
         if PREFER_BING_INFO:
             return self.getBingInfo()["userInfo"]["balance"]
-        return self.getDashboardData()["userStatus"]["availablePoints"]
+        return self.getDashboardData(forceRefresh)["userStatus"]["availablePoints"]
 
-    def getGoalPoints(self) -> int:
+    def getGoalPoints(self, forceRefresh=False) -> int:
         if PREFER_BING_INFO:
             return self.getBingInfo()["flyoutResult"]["userGoal"]["price"]
-        return self.getDashboardData()["userStatus"]["redeemGoal"]["price"]
+        return self.getDashboardData(forceRefresh)["userStatus"]["redeemGoal"]["price"]
 
-    def getGoalTitle(self) -> str:
+    def getGoalTitle(self, forceRefresh=False) -> str:
         if PREFER_BING_INFO:
             return self.getBingInfo()["flyoutResult"]["userGoal"]["title"]
-        return self.getDashboardData()["userStatus"]["redeemGoal"]["title"]
+        return self.getDashboardData(forceRefresh)["userStatus"]["redeemGoal"]["title"]
 
     def tryDismissAllMessages(self) -> None:
         byValues = [


### PR DESCRIPTION
> I'm currently testing this PR correctly (on multiple days) to avoid being referenced as "someone who removed two very important lines of code for some unknown reason" /jk

Re-creation of #293

I found that we can go directly to the activity url instead of clicking on the activity card. This could improve stability and performance.

> This doesn't work, for some reason we need to actually click on the card, even if the link is the same. Even opening it by wheel clicking on the card doesn't work; it needs a real left click. Probably a JS thing, I'm currently investigating.

> Finally reverse engineered it. Found the js that triggered completion, it simply fires a post request. I'm testing if it's better to reproduce this request, or simply call the js code that does it. I only tested calling the js for now, and it worked like a charm.

> Sending the request, even with the proper cookies, doesn't seems to work as smoothly as calling the js. I'm still investigating because il would be really cool, as it totally remove the need to be on the rewards dashboard.

> It needs a `__RequestVerificationToken` to work correctly. I found its location, currently testing it. I took the opportunity to remove the unnecessary refreshes, this may help prevent the bot from being detected.

> It works, but I need to fix a couple things, and more tests. I want to understand more of how it works. If some of my theories are true, this could be a great enhancement to the script.

> I'm currently flagged thanks to these tests, so I'm gonna pause this PR for now.

This PR apply this idea, among a couple other ones.

## Changed
- Removed the viewport settings in chrome (allows easier debugging, as scrolling in the chrome window in now possible without any issue)
  > ⚠️ This requires special attention, as I'm afraid it might lead to unwanted side effects. However, it didn't change anything when tested, and according to the [Chrome DevTools Protocol documentation](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride), these changes are only visual and are not observed by the page, so it seems to be ok.
- `activityTitle` assignation has been removed from the `try` clause (as used in the `except` clause)
- ~~Removed "click on activity card -> switch to new tab -> close tab after completion". Instead, we simply follow the activity link. (avoid errors where name is different, having to wait for click, and closing banners)~~ Not working for now
- `searchbar` focus and clean only if `activityTitle` in `CONFIG.activities.search` (avoid having to wait for timeout when unused)
- Info log when activity completed
- Use quotes when logging activity name
- General refactor to avoid useless statements
- Add spaces around accounts' emails when logging them at the bot's start
- Removed unused variables and attributes of `ReadToEarn`
- Removed useless refresh