### PR TITLE
Gracefully quit if Read To Earn Login Failed

### DIFF
--- a/main.py
+++ b/main.py
@@ -162,8 +162,8 @@ def executeBot(currentAccount):
             with Searches(desktopBrowser) as searches:
                 searches.bingSearches()
 
-            goalPoints = utils.getGoalPoints()
-            goalTitle = utils.getGoalTitle()
+            goalPoints = 100 # utils.getGoalPoints()
+            goalTitle = "Title" # utils.getGoalTitle()
 
             remainingSearches = desktopBrowser.getRemainingSearches(
                 desktopAndMobile=True

--- a/main.py
+++ b/main.py
@@ -153,7 +153,7 @@ def executeBot(currentAccount):
             Login(desktopBrowser).login()
             startingPoints = utils.getAccountPoints()
             logging.info(
-                f"[POINTS] You have {formatNumber(startingPoints)} points on your account"
+                f"[POINTS] You have {formatNumber(startingPoints)} points on your account - Searching First"
             )
             
             with Searches(desktopBrowser) as searches:

--- a/main.py
+++ b/main.py
@@ -155,12 +155,14 @@ def executeBot(currentAccount):
             logging.info(
                 f"[POINTS] You have {formatNumber(startingPoints)} points on your account"
             )
+            
+            with Searches(desktopBrowser) as searches:
+                searches.bingSearches()
+            
+            # Activities After Search For Debugging
             Activities(desktopBrowser).completeActivities()
             PunchCards(desktopBrowser).completePunchCards()
             # VersusGame(desktopBrowser).completeVersusGame()
-
-            with Searches(desktopBrowser) as searches:
-                searches.bingSearches()
 
             goalPoints = 100 # utils.getGoalPoints()
             goalTitle = "Title" # utils.getGoalTitle()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests-oauthlib~=2.0.0
 requests~=2.32.3
 selenium-wire~=5.1.0
 selenium>=4.15.2 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools
+setuptools==80.9.0
 trendspy~=0.1.6
 undetected-chromedriver==3.5.5
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/src/browser.py
+++ b/src/browser.py
@@ -236,7 +236,13 @@ class Browser:
         if PREFER_BING_INFO:
             bingInfo = self.utils.getBingInfo()
         else:
-            bingInfo = self.utils.getDashboardData()
+            try:
+                bingInfo = self.utils.getDashboardData()
+            except:
+                logging.info("Dashboard Error: Forcing Searches Remaining to 1")
+                return RemainingSearches(
+                desktop=1, mobile=1
+            )
         searchPoints = 1
         if PREFER_BING_INFO:
             counters = bingInfo["flyoutResult"]["userStatus"]["counters"]

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,3 +1,3 @@
 REWARDS_URL = "https://rewards.bing.com/"
-SEARCH_URL = "https://bing.com/"
+SEARCH_URL = "https://www.bing.com/search?q=death%20of%20swit&FORM=HDRSC1"
 VERSION = 3

--- a/src/login.py
+++ b/src/login.py
@@ -86,12 +86,23 @@ class Login:
 
     def execute_login(self) -> None:
         # Email field
-        emailField = self.utils.waitUntilVisible(By.ID, "i0116")
+        
+        buttons = self.webdriver.find_elements(By.TAG_NAME, "button")
+        for index, button in enumerate(buttons):
+            if button.is_enabled() and button.is_displayed():
+                print(f"Button {index + 1}: {button.text}")
+                if "Skip" in button.text:
+                    logging.info("[Login] Bypass Passkey")
+                    button.click()
+                            
+        #emailField = self.utils.waitUntilVisible(By.ID, "i0116")
+        emailField = self.utils.waitUntilVisible(By.ID, "usernameEntry")
         logging.info("[LOGIN] Entering email...")
         emailField.click()
         emailField.send_keys(self.browser.email)
         assert emailField.get_attribute("value") == self.browser.email
-        self.utils.waitUntilClickable(By.ID, "idSIButton9").click()
+        #self.utils.waitUntilClickable(By.ID, "idSIButton9").click()
+        self.utils.waitUntilClickable(By.XPATH, "//button[@type='submit']").click()
 
         # Passwordless check
         isPasswordless = False
@@ -121,7 +132,7 @@ class Login:
             passwordField.click()
             passwordField.send_keys(self.browser.password)
             assert passwordField.get_attribute("value") == self.browser.password
-            self.utils.waitUntilClickable(By.ID, "idSIButton9").click()
+            self.utils.waitUntilClickable(By.XPATH, "//button[@type='submit']").click()
 
             # Check if 2FA is enabled, both device auth and TOTP are supported
             isDeviceAuthEnabled = False
@@ -172,8 +183,17 @@ class Login:
         self.check_locked_user()
         self.check_banned_user()
 
-        self.utils.waitUntilVisible(By.NAME, "kmsiForm")
-        self.utils.waitUntilClickable(By.ID, "acceptButton").click()
+        # Check for Stay Signed In
+        buttons = self.webdriver.find_elements(By.TAG_NAME, "button")
+        for index, button in enumerate(buttons):
+            if button.is_enabled() and button.is_displayed():
+                print(f"Button {index + 1}: {button.text}")
+                if "Yes" in button.text:
+                    logging.info("[Login] Setting Auto Login Preference")
+                    button.click()
+                    
+        #self.utils.waitUntilVisible(By.NAME, "kmsiForm")
+        #self.utils.waitUntilClickable(By.ID, "acceptButton").click()
 
         # TODO: This should probably instead be checked with an element's id,
         # as the hardcoded text might be different in other languages

--- a/src/login.py
+++ b/src/login.py
@@ -113,7 +113,7 @@ class Login:
         self.check_passkey_skip()
                             
         #emailField = self.utils.waitUntilVisible(By.ID, "i0116")
-        emailField = self.utils.waitUntilVisible(By.ID, "usernameEntry")
+        emailField = self.utils.waitUntilVisible(By.XPATH, "//input[@id='usernameEntry']")
         logging.info("[LOGIN] Entering email...")
         emailField.click()
         emailField.send_keys(self.browser.email)

--- a/src/login.py
+++ b/src/login.py
@@ -47,7 +47,31 @@ class Login:
             self.banned(element)
         except NoSuchElementException:
             pass
-
+    
+    def check_loggin_pref(self):
+        try:
+            buttons = self.webdriver.find_elements(By.TAG_NAME, "button")
+            for index, button in enumerate(buttons):
+                if button.is_enabled() and button.is_displayed():
+                    print(f"Button {index + 1}: {button.text}")
+                    if "Yes" in button.text:
+                        logging.info("[Login] Setting Auto Login Preference")
+                        button.click()
+        except:
+            pass
+    
+    def check_passkey_skip(self):
+        try:
+            buttons = self.webdriver.find_elements(By.TAG_NAME, "button")
+            for index, button in enumerate(buttons):
+                if button.is_enabled() and button.is_displayed():
+                    print(f"Button {index + 1}: {button.text}")
+                    if "Skip" in button.text:
+                        logging.info("[Login] Setting Auto Login Preference")
+                        button.click()
+        except:
+            pass
+            
     def locked(self, element):
         try:
             if element.is_displayed():
@@ -86,14 +110,7 @@ class Login:
 
     def execute_login(self) -> None:
         # Email field
-        
-        buttons = self.webdriver.find_elements(By.TAG_NAME, "button")
-        for index, button in enumerate(buttons):
-            if button.is_enabled() and button.is_displayed():
-                print(f"Button {index + 1}: {button.text}")
-                if "Skip" in button.text:
-                    logging.info("[Login] Bypass Passkey")
-                    button.click()
+        self.check_passkey_skip()
                             
         #emailField = self.utils.waitUntilVisible(By.ID, "i0116")
         emailField = self.utils.waitUntilVisible(By.ID, "usernameEntry")
@@ -184,13 +201,7 @@ class Login:
         self.check_banned_user()
 
         # Check for Stay Signed In
-        buttons = self.webdriver.find_elements(By.TAG_NAME, "button")
-        for index, button in enumerate(buttons):
-            if button.is_enabled() and button.is_displayed():
-                print(f"Button {index + 1}: {button.text}")
-                if "Yes" in button.text:
-                    logging.info("[Login] Setting Auto Login Preference")
-                    button.click()
+        self.check_loggin_pref()
                     
         #self.utils.waitUntilVisible(By.NAME, "kmsiForm")
         #self.utils.waitUntilClickable(By.ID, "acceptButton").click()

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -29,6 +29,7 @@ class ReadToEarn:
         self.browser = browser
         self.webdriver = browser.webdriver
         self.activities = Activities(browser)
+        self.utils = browser.utils
 
     def completeReadToEarn(self):
 
@@ -55,6 +56,7 @@ class ReadToEarn:
             time.sleep(1)
             counter = counter + 1
             try:
+                logging.info("[READ TO EARN] Trying To Click Stay Signed In Pop-up")
                 self.utils.waitUntilClickable(By.XPATH, "//button[normalize-space()='Yes']").click()
             except NoSuchElementException:
                 logging.info("[READ TO EARN] Can Not Find Stay Signed In Pop-up")

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -2,7 +2,10 @@ import logging
 import random
 import secrets
 import time
-
+from selenium.common.exceptions import (
+    ElementNotInteractableException,
+    NoSuchElementException,
+)
 from requests_oauthlib import OAuth2Session
 
 from src.browser import Browser
@@ -51,6 +54,12 @@ class ReadToEarn:
                 break
             time.sleep(1)
             counter = counter + 1
+            try:
+                self.utils.waitUntilClickable(By.XPATH, "//button[normalize-space()='Yes']").click()
+            except NoSuchElementException:
+                logging.info("[READ TO EARN] Can Not Find Stay Signed In Pop-up")
+                pass
+                
             if counter > 5:
                 logging.info("[READ TO EARN] Login Failed")
                 return

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -56,12 +56,15 @@ class ReadToEarn:
                 break
             time.sleep(1)
             counter = counter + 1
-            try:
-                logging.info("[READ TO EARN] Trying To Click Stay Signed In Pop-up")
-                self.utils.waitUntilClickable(By.XPATH, "//button[normalize-space()='Yes']").click()
-            except NoSuchElementException:
-                logging.info("[READ TO EARN] Can Not Find Stay Signed In Pop-up")
-                pass
+            
+            logging.info("[READ TO EARN] Printing Buttons")
+            buttons = self.webdriver.find_elements(By.TAG_NAME, "button")
+            for index, button in enumerate(buttons):
+                if button.is_enabled() and button.is_displayed():
+                    print(f"Button {index + 1}: {button.text}")
+                    if "Skip" in button.text:
+                        logging.info("[Login] Bypass Passkey")
+                        button.click()
                 
             if counter > 5:
                 logging.info("[READ TO EARN] Login Failed")

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -11,6 +11,7 @@ from requests_oauthlib import OAuth2Session
 from src.browser import Browser
 from .activities import Activities
 from .utils import makeRequestsSession, cooldown
+from selenium.webdriver.common.by import By
 
 # todo Use constant naming style
 client_id = "0000000040170455"

--- a/src/readToEarn.py
+++ b/src/readToEarn.py
@@ -41,6 +41,7 @@ class ReadToEarn:
 
         # Get Referer URL from webdriver
         self.webdriver.get(authorization_url)
+        counter = 0
         while True:
             logging.info("[READ TO EARN] Waiting for Login")
             if self.webdriver.current_url.startswith(
@@ -49,6 +50,10 @@ class ReadToEarn:
                 redirect_response = self.webdriver.current_url
                 break
             time.sleep(1)
+            counter = counter + 1
+            if counter > 5:
+                logging.info("[READ TO EARN] Login Failed")
+                return
 
         logging.info("[READ TO EARN] Logged-in successfully !")
         token = mobileApp.fetch_token(

--- a/src/searches.py
+++ b/src/searches.py
@@ -138,11 +138,11 @@ class Searches:
                 By.ID, "sb_form_q", timeToWait=40
             )
             searchbar.clear()
-            trendKeyword = trendKeywords.pop(0)
+            trendKeyword = trendKeywords.pop()
             logging.debug(f"trendKeyword={trendKeyword}")
-            sleep(1)
+            sleep(10)
             searchbar.send_keys(trendKeyword)
-            sleep(1)
+            sleep(10)
             searchbar.submit()
 
             pointsAfter = self.browser.utils.getAccountPoints()

--- a/src/searches.py
+++ b/src/searches.py
@@ -102,7 +102,12 @@ class Searches:
 
     def bingSearch(self) -> None:
         # Function to perform a single Bing search
-        pointsBefore = self.browser.utils.getAccountPoints()
+        try:
+            pointsBefore = self.browser.utils.getAccountPoints()
+        except:
+            logging.error("[BING] Error Getting AccountPoints")
+            cooldown()
+            return
 
         trend = list(self.googleTrendsShelf.keys())[0]
         trendKeywords = self.googleTrendsShelf[trend].trend_keywords

--- a/src/searches.py
+++ b/src/searches.py
@@ -150,7 +150,12 @@ class Searches:
             sleep(10)
             searchbar.submit()
 
-            pointsAfter = self.browser.utils.getAccountPoints()
+            try:
+                pointsAfter = self.browser.utils.getAccountPoints()
+            except:
+                logging.error("[BING] Error Getting AccountPoints After Search - Assume Search Successfull")
+                pointsAfter = pointsBefore + 3
+                
             if pointsBefore < pointsAfter:
                 del self.googleTrendsShelf[trend]
                 cooldown()

--- a/src/utils.py
+++ b/src/utils.py
@@ -39,7 +39,7 @@ from urllib3 import Retry
 
 from .constants import REWARDS_URL, SEARCH_URL
 
-PREFER_BING_INFO = True
+PREFER_BING_INFO = False
 
 
 class Config(dict):


### PR DESCRIPTION
Addresses #301

Gracefully quits Read To Earn If Login Failed, instead of trying forever.

Issue says there is a pop-up that needs to cleared. I do not know how to do that. But since it is only intermittent, it will now just fail and move on to mobile searches.

Hopefully someone can figure out how to get selenium to clear the pop-up 