### PR TITLE
Refactor tryDismissAllMessages

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -374,17 +374,20 @@ class Utils:
             (By.ID, "idSIButton9"),
             (By.ID, "bnp_btn_accept"),
             (By.ID, "acceptButton"),
-            # (By.CLASS_NAME, "dashboardPopUpPopUpSelectButton"),
+            (By.CLASS_NAME, "dashboardPopUpPopUpSelectButton"),  # seems to be unclickable
             (By.CSS_SELECTOR, "#cookie-banner button:first-child"),
             (By.CSS_SELECTOR, "#wcpConsentBannerCtrl button:first-child"),
         ]
         dismissButtons = []
         for by, value in byValues:
-            with contextlib.suppress(NoSuchElementException):
+            with contextlib.suppress(NoSuchElementException, TimeoutException):
                 dismissButtons.extend(self.webdriver.find_elements(by=by, value=value))
         for dismissButton in dismissButtons:
-            logging.debug(f"[DISMISS] Dismissing an element by clicking on {dismissButton.get_attribute('outerHTML')}")
-            dismissButton.click()
+            try:
+                dismissButton.click()
+                logging.debug(f"[DISMISS] Dismissed an element by clicking on {dismissButton.get_attribute('outerHTML')}")
+            except (ElementNotInteractableException, ElementClickInterceptedException, TimeoutException):
+                logging.error(f"[DISMISS] Error dismissing an element by clicking on {dismissButton.get_attribute('outerHTML')}")
 
     def switchToNewTab(self, timeToWait: float = 10, closeTab: bool = False) -> None:
         time.sleep(timeToWait)

--- a/src/utils.py
+++ b/src/utils.py
@@ -383,7 +383,7 @@ class Utils:
             with contextlib.suppress(NoSuchElementException):
                 dismissButtons.extend(self.webdriver.find_elements(by=by, value=value))
         for dismissButton in dismissButtons:
-            logging.debug(f"[DISMISS] Dismissing an element by clicking on {dismissButton}")
+            logging.debug(f"[DISMISS] Dismissing an element by clicking on {dismissButton.get_attribute('outerHTML')}")
             dismissButton.click()
 
     def switchToNewTab(self, timeToWait: float = 10, closeTab: bool = False) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -383,6 +383,7 @@ class Utils:
             with contextlib.suppress(NoSuchElementException):
                 dismissButtons.extend(self.webdriver.find_elements(by=by, value=value))
         for dismissButton in dismissButtons:
+            logging.debug(f"[DISMISS] Dismissing an element by clicking on {dismissButton}")
             dismissButton.click()
 
     def switchToNewTab(self, timeToWait: float = 10, closeTab: bool = False) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -366,6 +366,7 @@ class Utils:
         return self.getDashboardData()["userStatus"]["redeemGoal"]["title"]
 
     def tryDismissAllMessages(self) -> None:
+        print("Trying to dismiss all messages...")
         byValues = [
             (By.ID, "iLandingViewAction"),
             (By.ID, "iShowSkip"),
@@ -374,20 +375,16 @@ class Utils:
             (By.ID, "idSIButton9"),
             (By.ID, "bnp_btn_accept"),
             (By.ID, "acceptButton"),
-            (By.CSS_SELECTOR, ".dashboardPopUpPopUpSelectButton"),
+            (By.CLASS_NAME, "dashboardPopUpPopUpSelectButton"),
+            (By.CSS_SELECTOR, "#cookie-banner button:first-child"),
+            (By.CSS_SELECTOR, "#wcpConsentBannerCtrl button:first-child"),
         ]
-        for byValue in byValues:
-            dismissButtons = []
+        dismissButtons = []
+        for by, value in byValues:
             with contextlib.suppress(NoSuchElementException):
-                dismissButtons = self.webdriver.find_elements(
-                    by=byValue[0], value=byValue[1]
-                )
-            for dismissButton in dismissButtons:
-                dismissButton.click()
-        with contextlib.suppress(NoSuchElementException):
-            self.webdriver.find_element(By.ID, "cookie-banner").find_element(
-                By.TAG_NAME, "button"
-            ).click()
+                dismissButtons.append(*self.webdriver.find_elements(by=by, value=value))
+        for dismissButton in dismissButtons:
+            dismissButton.click()
 
     def switchToNewTab(self, timeToWait: float = 10, closeTab: bool = False) -> None:
         time.sleep(timeToWait)

--- a/src/utils.py
+++ b/src/utils.py
@@ -387,7 +387,7 @@ class Utils:
                 dismissButton.click()
                 logging.debug(f"[DISMISS] Dismissed an element by clicking on {dismissButton.get_attribute('outerHTML')}")
             except (ElementNotInteractableException, ElementClickInterceptedException, TimeoutException):
-                logging.error(f"[DISMISS] Error dismissing an element by clicking on {dismissButton.get_attribute('outerHTML')}")
+                logging.warning(f"[DISMISS] Can't dismiss an element by clicking on {dismissButton.get_attribute('outerHTML')}")
 
     def switchToNewTab(self, timeToWait: float = 10, closeTab: bool = False) -> None:
         time.sleep(timeToWait)

--- a/src/utils.py
+++ b/src/utils.py
@@ -374,7 +374,7 @@ class Utils:
             (By.ID, "idSIButton9"),
             (By.ID, "bnp_btn_accept"),
             (By.ID, "acceptButton"),
-            (By.CLASS_NAME, "dashboardPopUpPopUpSelectButton"),
+            # (By.CLASS_NAME, "dashboardPopUpPopUpSelectButton"),
             (By.CSS_SELECTOR, "#cookie-banner button:first-child"),
             (By.CSS_SELECTOR, "#wcpConsentBannerCtrl button:first-child"),
         ]

--- a/src/utils.py
+++ b/src/utils.py
@@ -366,7 +366,6 @@ class Utils:
         return self.getDashboardData()["userStatus"]["redeemGoal"]["title"]
 
     def tryDismissAllMessages(self) -> None:
-        print("Trying to dismiss all messages...")
         byValues = [
             (By.ID, "iLandingViewAction"),
             (By.ID, "iShowSkip"),
@@ -382,7 +381,7 @@ class Utils:
         dismissButtons = []
         for by, value in byValues:
             with contextlib.suppress(NoSuchElementException):
-                dismissButtons.append(*self.webdriver.find_elements(by=by, value=value))
+                dismissButtons.extend(self.webdriver.find_elements(by=by, value=value))
         for dismissButton in dismissButtons:
             dismissButton.click()
 


### PR DESCRIPTION
Fix #289

This PR refactors `tryDismissAllMessages` to simplify it and ensure a proper error handling.

---

Creating this as a draft PR for now, as I need @cal4's opinion on something:
As shown in #289, the `dashboardPopUpPopUpSelectButton` button doesn't seem to be clickable anymore.

```
2025-05-02 21:54:07,717 [DEBUG] [DISMISS] Dismissing an element by clicking on <a class="dashboardPopUpPopUpSelectButton ng-binding" ng-click="$ctrl.hidePopUpAndApplyFunction($event)" data-bi-id="rx-nav-popup" target="_self" id="reward_pivot_earn">
                
            </a>
Traceback (most recent call last):
  File "c:\Tools\MS-Rewards-Farmer\klept0\fix-cookie-banner\src\activities.py", line 163, in completeActivity
    self.browser.utils.click(activityElement)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "c:\Tools\MS-Rewards-Farmer\klept0\fix-cookie-banner\src\utils.py", line 414, in click
    self.tryDismissAllMessages()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "c:\Tools\MS-Rewards-Farmer\klept0\fix-cookie-banner\src\utils.py", line 390, in tryDismissAllMessages
    dismissButton.click()
    ~~~~~~~~~~~~~~~~~~~^^
selenium.common.exceptions.ElementNotInteractableException: Message: element not interactable
  (Session info: chrome=136.0.7103.48)
```

Do you think I should just remove its detection or leave it as is (try to click on it and ignore its error)? I'm not sure if the fact that it's not interactable is exceptional or if it's always the case now.